### PR TITLE
Updated email address matching pattern

### DIFF
--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -24,6 +24,8 @@ namespace MyAddressExtractor
                     continue;
                 if (email.Contains('..'))
                     continue;
+                if (email.Contains('.@'))
+                    continue;
                 if (email.Length >= 256)
                     continue;
                 // Handle cases such as: foobar@_.com, oobar@f_b.com

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -19,6 +19,14 @@ namespace MyAddressExtractor
 
             foreach (Match match in matches)
             {
+                var email = match.Value;
+                if (address.Contains('*'))
+                    continue;
+                if (address.Contains('..'))
+                    continue;
+                if (address.Length >= 256)
+                    continue;
+                
                 uniqueAddresses.Add(match.Value.ToLower());
             }
 

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -13,7 +13,7 @@ namespace MyAddressExtractor
 
         public List<string> ExtractAddresses(string content)
         {
-            string addressPattern = @"\b(?<!\.)[\w\.\-!#$%&'*+-/=?^_`{|}~""]+(?<!\.)@([\w\-]+\.)+[\w]{2,}\b(?<!\s)";
+            string addressPattern = @"(?!\.)[\w\.\-!#$%&'+-/=?^_`{|}~""\\]+(?<!\.)@([\w\-]+\.)+[\w]{2,}\b(?<!\s)";
             var matches = Regex.Matches(content, addressPattern);
             var uniqueAddresses = new HashSet<string>();
 

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -31,6 +31,9 @@ namespace MyAddressExtractor
                 // Handle cases such as: foobar@_.com, oobar@f_b.com
                 if (email.Substring(email.LastIndexOf("@")).Contains("_"))
                     continue;
+                // Handle cases such as: foo@bar.1com, foo@bar.12com
+                if (int.TryParse(Name[Name.LastIndexOf(".")+1].ToString(), out _))
+                    continue;
                 
                 uniqueAddresses.Add(match.Value.ToLower());
             }

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -13,7 +13,7 @@ namespace MyAddressExtractor
 
         public List<string> ExtractAddresses(string content)
         {
-            string addressPattern = @"\b[a-zA-Z0-9\.\-_\+]+@[a-zA-Z0-9\.\-_]+\.[a-zA-Z]+\b";
+            string addressPattern = @"\b[^.\s][\w\.\-!#$%&'*+-/=?^_`{|}~]+@([\w\-]+\.)+[\w]{2,}\b";
             var matches = Regex.Matches(content, addressPattern);
             var uniqueAddresses = new HashSet<string>();
 

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -13,7 +13,7 @@ namespace MyAddressExtractor
 
         public List<string> ExtractAddresses(string content)
         {
-            string addressPattern = @"(?!\.)[\w\.\-!#$%&'+-/=?^_`{|}~""\\]+(?<!\.)@([\w\-]+\.)+[\w]{2,}\b(?<!\s)";
+            string addressPattern = @"(?!\.)[a-zA-Z0-9\.\-!#$%&'+-/=?^_`{|}~""\\]+(?<!\.)@([a-zA-Z0-9\-]+\.)+[a-zA-Z0-9]{2,}\b(?<!\s)";
             var matches = Regex.Matches(content, addressPattern);
             var uniqueAddresses = new HashSet<string>();
 
@@ -32,7 +32,7 @@ namespace MyAddressExtractor
                 if (email.Substring(email.LastIndexOf("@")).Contains("_"))
                     continue;
                 // Handle cases such as: foo@bar.1com, foo@bar.12com
-                if (int.TryParse(Name[Name.LastIndexOf(".")+1].ToString(), out _))
+                if (int.TryParse(email[email.LastIndexOf(".")+1].ToString(), out _))
                     continue;
                 
                 uniqueAddresses.Add(match.Value.ToLower());

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -22,9 +22,9 @@ namespace MyAddressExtractor
                 var email = match.Value;
                 if (email.Contains('*'))
                     continue;
-                if (email.Contains('..'))
+                if (email.Contains(".."))
                     continue;
-                if (email.Contains('.@'))
+                if (email.Contains(".@"))
                     continue;
                 if (email.Length >= 256)
                     continue;

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -20,11 +20,14 @@ namespace MyAddressExtractor
             foreach (Match match in matches)
             {
                 var email = match.Value;
-                if (address.Contains('*'))
+                if (email.Contains('*'))
                     continue;
-                if (address.Contains('..'))
+                if (email.Contains('..'))
                     continue;
-                if (address.Length >= 256)
+                if (email.Length >= 256)
+                    continue;
+                // Handle cases such as: foobar@_.com, oobar@f_b.com
+                if (email.Substring(email.LastIndexOf("@")).Contains("_"))
                     continue;
                 
                 uniqueAddresses.Add(match.Value.ToLower());

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -13,7 +13,7 @@ namespace MyAddressExtractor
 
         public List<string> ExtractAddresses(string content)
         {
-            string addressPattern = @"\b[^.\s][\w\.\-!#$%&'*+-/=?^_`{|}~]+@([\w\-]+\.)+[\w]{2,}\b";
+            string addressPattern = @"\b(?<!\.)[\w\.\-!#$%&'*+-/=?^_`{|}~""]+(?<!\.)@([\w\-]+\.)+[\w]{2,}\b(?<!\s)";
             var matches = Regex.Matches(content, addressPattern);
             var uniqueAddresses = new HashSet<string>();
 


### PR DESCRIPTION
Handled most of the cases mentioned under "LegacyTests.cs" file.

| Sample Email                        | Correctly Matched |
|----------------------------------------|--------|
`Mary&Jane@example.org`          		        | ✅
`""test\""blah""@example.com`                    | ✅
`customer/department@example.com`        | ✅
`$A12345@example.com`          		        | ✅
`!def!xyz%abc@example.com`          	        | ✅
`_Yosemite.Sam@example.com`          	        | ✅
`Ima.Fool@example.com`          		        | ✅
`foobar@x.com`          				        | ✅
`foobar@c0m.com`          				| ✅
`foobar@c_m.com`          				| ✅
`foo@bar_.com`          				        | ✅
`foo@666.com`          					| ✅
`1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com`  | ✅

Invalid cases handled:

| Invalid Email Address | Regex Invalidating? |
|--------|--------|
`char)8 + "ar.com`     		| ✅
`char)9 + "ar.com`     		| ✅
`char)127 + "ar.com`   		| ✅
`.wooly@example.com`   		| ✅
`pootietang.@example.com`   | ✅
`.@example.com`   			| ✅
`foo@bar`   				| ✅
`foo@bar.a` |✅

Pattern not being handled via Regex:

| Email | Description | Handled via Code? |
|--------|--------|--------|
| `pootietang.@example.com` | dot_before_at | ✅ |
| `wo..oly@example.com` | consecutive_dots | ✅ |
| `foo@bar.1com` | tld_starting_with_number | ✅ |
| `foobar@_.com` | domain_with_underscore | ✅ |
| `1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com` | email_of_256_chars | ✅ |


Fix for issue https://github.com/HaveIBeenPwned/EmailAddressExtractor/issues/5