### PR TITLE
[.net7] Improvements to performance

### DIFF
--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -3,19 +3,28 @@ using System.Text.RegularExpressions;
 
 namespace MyAddressExtractor
 {
-    public class AddressExtractor
+    public partial class AddressExtractor
     {
-        public List<string> ExtractAddressesFromFile(string inputFilePath)
+        [GeneratedRegex(@"(?!\.)[a-zA-Z0-9\.\-!#$%&'+-/=?^_`{|}~""\\]+(?<!\.)@([a-zA-Z0-9\-]+\.)+[a-zA-Z0-9]{2,}\b(?<!\s)")]
+        public static partial Regex EmailRegex();
+        
+        public async ValueTask<HashSet<string>> ExtractAddressesFromFileAsync(string inputFilePath, CancellationToken cancellation = default)
         {
-            string fileContent = File.ReadAllText(inputFilePath);
-            return ExtractAddresses(fileContent);
+            var list = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            await foreach(string line in File.ReadLinesAsync(inputFilePath, cancellation))
+            {
+                foreach (string address in this.ExtractAddresses(line)) {
+                    list.Add(address);
+                }
+            }
+            
+            return list;
         }
 
-        public List<string> ExtractAddresses(string content)
+        public IEnumerable<string> ExtractAddresses(string content)
         {
-            string addressPattern = @"(?!\.)[a-zA-Z0-9\.\-!#$%&'+-/=?^_`{|}~""\\]+(?<!\.)@([a-zA-Z0-9\-]+\.)+[a-zA-Z0-9]{2,}\b(?<!\s)";
-            var matches = Regex.Matches(content, addressPattern);
-            var uniqueAddresses = new HashSet<string>();
+            var matches = AddressExtractor.EmailRegex()
+                .Matches(content);
 
             foreach (Match match in matches)
             {
@@ -35,27 +44,25 @@ namespace MyAddressExtractor
                 if (int.TryParse(email[email.LastIndexOf(".")+1].ToString(), out _))
                     continue;
                 
-                uniqueAddresses.Add(match.Value.ToLower());
+                yield return match.Value;
             }
-
-            return uniqueAddresses.OrderBy(a => a).ToList();
         }
 
-        public void SaveAddresses(string filePath, List<string> addresses)
+        public async ValueTask SaveAddressesAsync(string filePath, IEnumerable<string> addresses, CancellationToken cancellation = default)
         {
-            File.WriteAllLines(filePath, addresses);
+            await File.WriteAllLinesAsync(filePath, addresses.OrderBy(a => a), cancellation);
         }
 
-        public void SaveReport(string filePath, Dictionary<string, int> uniqueAddressesPerFile)
+        public async ValueTask SaveReportAsync(string filePath, Dictionary<string, int> uniqueAddressesPerFile, CancellationToken cancellation = default)
         {
             var reportContent = new StringBuilder("Unique addresses per file:\n");
-
+            
             foreach (var entry in uniqueAddressesPerFile)
             {
                 reportContent.AppendLine($"{entry.Key}: {entry.Value}");
             }
-
-            File.WriteAllText(filePath, reportContent.ToString());
+            
+            await File.WriteAllTextAsync(filePath, reportContent.ToString(), cancellation);
         }
     }
 }

--- a/src/AddressExtractor.csproj
+++ b/src/AddressExtractor.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -18,7 +18,7 @@ namespace MyAddressExtractor
             InvalidArguments = 2
         }
 
-        static int Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             var inputFilePaths = new List<string>();
             var outputFilePath = "addresses_output.txt";
@@ -46,11 +46,11 @@ namespace MyAddressExtractor
             try
             {
                 var stopwatch = Stopwatch.StartNew();
-                var allAddresses = new HashSet<string>();
+                var allAddresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var inputFilePath in inputFilePaths)
                 {
-                    var addresses = extractor.ExtractAddressesFromFile(inputFilePath);
+                    var addresses = await extractor.ExtractAddressesFromFileAsync(inputFilePath, CancellationToken.None);
                     allAddresses.UnionWith(addresses);
                     uniqueAddressesPerFile.Add(inputFilePath, addresses.Count);
                 }
@@ -62,8 +62,8 @@ namespace MyAddressExtractor
                 long rate = (long)(allAddresses.Count / (stopwatch.ElapsedMilliseconds / 1000.0));
                 Console.WriteLine($"Extraction rate: {rate}/s");
 
-                extractor.SaveAddresses(outputFilePath, allAddresses.ToList());
-                extractor.SaveReport(reportFilePath, uniqueAddressesPerFile);
+                await extractor.SaveAddressesAsync(outputFilePath, allAddresses, CancellationToken.None);
+                await extractor.SaveReportAsync(reportFilePath, uniqueAddressesPerFile, CancellationToken.None);
 
                 Console.WriteLine($"Addresses saved to {outputFilePath}");
                 Console.WriteLine($"Report saved to {reportFilePath}");

--- a/test/AddressExtractorTest.csproj
+++ b/test/AddressExtractorTest.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
 <ItemGroup>

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -5,13 +5,13 @@ using MyAddressExtractor;
 public class MyAddressExtractorTest
 {
     [TestMethod]
-    public void correct_number_of_addresses_are_extracted_from_file()
+    public async Task correct_number_of_addresses_are_extracted_from_file()
     {
         // Arrange
         var sut = new AddressExtractor();
 
         // Act
-        var result = sut.ExtractAddressesFromFile(@"../../../../TestData/SingleFile/SingleSmallFile.txt");
+        var result = await sut.ExtractAddressesFromFileAsync(@"../../../../TestData/SingleFile/SingleSmallFile.txt");
 
         // Assert
         Assert.IsTrue(result.Count == 12, "Parsing should pass");
@@ -28,7 +28,7 @@ public class MyAddressExtractorTest
         var result = sut.ExtractAddresses(addresses);
 
         // Assert
-        Assert.IsTrue(result.Count == 1, "Same addresses of different case should be merged");
+        Assert.IsTrue(result.Count() == 1, "Same addresses of different case should be merged");
     }   
     
     [TestMethod]


### PR DESCRIPTION
Rebased PR #8 

I removed a few cases where LINQ was being used to `.ToList` when it was unecessary to remap. Writing lines to the file takes an Enumerable and can be passed a `Set<string>` without needing to convert it back to a `List<string>`

I also noticed that I had removed an `OrderBy()` that was being called while collecting the emails, and moved the sort to when it was being written to file, which may help in cases of large files.