### PR TITLE
Adjusted the Tests in the Test module

### DIFF
--- a/test/Program.cs
+++ b/test/Program.cs
@@ -25,10 +25,12 @@ public class MyAddressExtractorTest
         const string addresses = "test@example.com TEST@EXAMPLE.COM";
 
         // Act
-        var result = sut.ExtractAddresses(addresses);
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        result.UnionWith(sut.ExtractAddresses(addresses));
 
         // Assert
-        Assert.IsTrue(result.Count() == 1, "Same addresses of different case should be merged");
+        Assert.IsTrue(result.Count == 1, "Same addresses of different case should be merged");
     }   
     
     [TestMethod]

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -20,31 +20,41 @@ public class MyAddressExtractorTest
     [TestMethod]
     public void email_addresses_are_not_case_sensitive()
     {
-        // Arrange
-        var sut = new AddressExtractor();
         const string addresses = "test@example.com TEST@EXAMPLE.COM";
 
         // Act
-        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        result.UnionWith(sut.ExtractAddresses(addresses));
+        var result = this.ExtractAddresses(addresses);
 
         // Assert
         Assert.IsTrue(result.Count == 1, "Same addresses of different case should be merged");
-    }   
+    }
     
     [TestMethod]
     public void email_addresses_are_converted_to_lowercase()
     {
         // Arrange
-        var sut = new AddressExtractor();
         const string input = "TEST@EXAMPLE.COM";
         const string expected = "test@example.com";
 
         // Act
-        var result = sut.ExtractAddresses(input).First();
+        var result = this.ExtractAddresses(input);
+
+        result.Add(expected);
 
         // Assert
-        Assert.AreEqual(expected, result, "Address should always be converted to lowercase");
+        Assert.IsTrue(result.Count == 1, "Address should always be converted to lowercase");
+    }
+
+    /// <summary>
+    /// Extract the addresses from the Address Extractor and wrap it into a set
+    /// Wrapping the <see cref="IEnumerable{String}"/> here instead of within the Method
+    /// prevents the overhead of creating a Set for every iteration in Production
+    /// </summary>
+    private HashSet<string> ExtractAddresses(string input)
+    {
+        var extractor = new AddressExtractor();
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        set.UnionWith(extractor.ExtractAddresses(input));
+        return set;
     }
 }


### PR DESCRIPTION
I broke the tests a bit in my last PR since I made `ExtractAddresses()` into an `IEnumerable` method, which does remove some overhead of creating a new `HashSet` for every call to get Matches.

The tests relied on the `HashSet` being returned, and do not run successfully afterward its change.

This creates a private wrapper method that wraps the returned Enumerable back into a HashSet.