### PR TITLE
Performance tweaks

### DIFF
--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -55,7 +55,12 @@ namespace MyAddressExtractor
 
         public async ValueTask SaveAddressesAsync(string filePath, IEnumerable<string> addresses, CancellationToken cancellation = default)
         {
-            await File.WriteAllLinesAsync(filePath, addresses.OrderBy(a => a, StringComparer.OrdinalIgnoreCase), cancellation);
+            await File.WriteAllLinesAsync(
+                filePath,
+                addresses.Select(address => address.ToLowerInvariant())
+                    .OrderBy(address => address, StringComparer.OrdinalIgnoreCase),
+                cancellation
+            );
         }
 
         public async ValueTask SaveReportAsync(string filePath, IDictionary<string, Count> uniqueAddressesPerFile, CancellationToken cancellation = default)

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -11,7 +11,7 @@ namespace MyAddressExtractor {
         protected readonly Stopwatch Stopwatch = Stopwatch.StartNew();
         private readonly Timer Timer;
 
-        public AddressExtractorMonitor(): this(TimeSpan.FromSeconds(1)) {}
+        public AddressExtractorMonitor(): this(TimeSpan.FromMinutes(1)) {}
         public AddressExtractorMonitor(TimeSpan iterate)
         {
             this.Timer = new Timer(_ => this.Log(), null, iterate, iterate);

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -6,11 +6,12 @@ namespace MyAddressExtractor {
         private readonly AddressExtractor Extractor = new();
         protected readonly IDictionary<string, Count> Files = new ConcurrentDictionary<string, Count>();
         protected readonly ISet<string> Addresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        protected int Lines { get; private set; }
 
         protected readonly Stopwatch Stopwatch = Stopwatch.StartNew();
         private readonly Timer Timer;
 
-        public AddressExtractorMonitor(): this(TimeSpan.FromMinutes(1)) {}
+        public AddressExtractorMonitor(): this(TimeSpan.FromSeconds(1)) {}
         public AddressExtractorMonitor(TimeSpan iterate)
         {
             this.Timer = new Timer(_ => this.Log(), null, iterate, iterate);
@@ -26,8 +27,9 @@ namespace MyAddressExtractor {
                 this.Files.Add(inputFilePath, count);
                 await foreach(var email in this.Extractor.ExtractAddressesFromFileAsync(inputFilePath, cancellation))
                 {
-                    this.Addresses.Add(email);
-                    count.Value = addresses++;
+                    if (this.Addresses.Add(email))
+                        count.Value = addresses++;
+                    this.Lines++;
                 }
             }
         }
@@ -36,9 +38,9 @@ namespace MyAddressExtractor {
         {
             Console.WriteLine($"Extraction time: {this.Stopwatch.ElapsedMilliseconds:n0}ms");
             Console.WriteLine($"Addresses extracted: {this.Addresses.Count:n0}");
-            // Extraction does not currently process per row, so we do not have the row count at this time
-            long rate = (long)(this.Addresses.Count / (this.Stopwatch.ElapsedMilliseconds / 1000.0));
-            Console.WriteLine($"Extraction rate: {rate:n0}/s\n");
+            long rate = (long)(this.Lines / (this.Stopwatch.ElapsedMilliseconds / 1000.0));
+            Console.WriteLine($"Read lines total: {this.Lines:n0}");
+            Console.WriteLine($"Read lines rate: {rate:n0}/s\n");
         }
 
         public async ValueTask SaveAsync(string outputFilePath, string reportFilePath, CancellationToken cancellation = default)


### PR DESCRIPTION
This changes the File reader from using the `File.ReadByLineAsync` to a `FileStream` and a `StreamReader`. Using the `FileStream` in `SequentialScan` mode should help with reading speeds since we know we're not backtracking in the file.

The read time of 69,949,440 lines was 191 seconds, though this is only a bunch of garbage emails listed sequentially in a file.

I also added a `Lines` count read to the Monitor that will keep track of total lines read, and moved the value incrementor inside of a `if-added` so that duplicate emails aren't counted more than once.