### PR TITLE
Added directory scanning

### DIFF
--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -43,10 +43,10 @@ namespace MyAddressExtractor {
             Console.WriteLine($"Read lines rate: {rate:n0}/s\n");
         }
 
-        public async ValueTask SaveAsync(string outputFilePath, string reportFilePath, CancellationToken cancellation = default)
+        public async ValueTask SaveAsync(CancellationToken cancellation = default)
         {
-            await this.Extractor.SaveAddressesAsync(outputFilePath, this.Addresses, cancellation);
-            await this.Extractor.SaveReportAsync(reportFilePath, this.Files, cancellation);
+            await this.Extractor.SaveAddressesAsync(CommandLineProcessor.OUTPUT_FILE_PATH, this.Addresses, cancellation);
+            await this.Extractor.SaveReportAsync(CommandLineProcessor.REPORT_FILE_PATH, this.Files, cancellation);
         }
 
         public async ValueTask DisposeAsync()

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -45,8 +45,17 @@ namespace MyAddressExtractor {
 
         public async ValueTask SaveAsync(CancellationToken cancellation = default)
         {
-            await this.Extractor.SaveAddressesAsync(CommandLineProcessor.OUTPUT_FILE_PATH, this.Addresses, cancellation);
-            await this.Extractor.SaveReportAsync(CommandLineProcessor.REPORT_FILE_PATH, this.Files, cancellation);
+            string output = CommandLineProcessor.OUTPUT_FILE_PATH;
+            string report = CommandLineProcessor.REPORT_FILE_PATH;
+            if (!string.IsNullOrWhiteSpace(output))
+            {
+                await this.Extractor.SaveAddressesAsync(output, this.Addresses, cancellation);
+            }
+
+            if (!string.IsNullOrWhiteSpace(report))
+            {
+                await this.Extractor.SaveReportAsync(report, this.Files, cancellation);
+            }
         }
 
         public async ValueTask DisposeAsync()

--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -7,7 +7,9 @@ namespace MyAddressExtractor
     {
         public static string OUTPUT_FILE_PATH { get; private set; } = "addresses_output.txt";
         public static string REPORT_FILE_PATH { get; private set; } = "report.txt";
-        
+
+        public static bool OPERATE_RECURSIVELY { get; private set; } = false;
+
         internal static void Process(string[] args, IList<string> inputFilePaths)
         {
             if (args.Length == 0)
@@ -50,6 +52,9 @@ namespace MyAddressExtractor
                             var option = arg[1..];
                             switch (option)
                             {
+                                case "-recursive":
+                                    OPERATE_RECURSIVELY = true;
+                                    break;
                                 case "o":
                                     expectingOutput = true;
                                     break;
@@ -124,6 +129,8 @@ namespace MyAddressExtractor
             Console.WriteLine("input                One or more input file paths");
             Console.WriteLine("-o output            File path to write output file");
             Console.WriteLine("-r report            File path to write report file");
+            Console.WriteLine("");
+            Console.WriteLine("--recursive          Recursively enters directories provided to search for files");
         }
 
         static void Version()

--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -3,9 +3,12 @@ using System.Reflection;
 
 namespace MyAddressExtractor
 {
-    internal class CommandLineProcessor
+    internal static class CommandLineProcessor
     {
-        internal static void Process(string[] args, IList<string> inputFilePaths, ref string outputFilePath, ref string reportFilePath)
+        public static string OUTPUT_FILE_PATH { get; private set; } = "addresses_output.txt";
+        public static string REPORT_FILE_PATH { get; private set; } = "report.txt";
+        
+        internal static void Process(string[] args, IList<string> inputFilePaths)
         {
             if (args.Length == 0)
             {
@@ -24,7 +27,7 @@ namespace MyAddressExtractor
                     {
                         throw new ArgumentException("Missing output file path after -o option");
                     }
-                    outputFilePath = arg;
+                    OUTPUT_FILE_PATH = arg;
                     expectingOutput = false;
                 }
                 else if (expectingReport)
@@ -34,7 +37,7 @@ namespace MyAddressExtractor
                     {
                         throw new ArgumentException("Missing report file path after -r option");
                     }
-                    reportFilePath = arg;
+                    REPORT_FILE_PATH = arg;
                     expectingReport = false;
                 }
                 else
@@ -98,6 +101,16 @@ namespace MyAddressExtractor
             {
                 throw new ArgumentException("No input file paths specified");
             }
+        }
+
+        internal static bool WaitInput()
+        {
+            Console.WriteLine("Press ANY KEY to continue. Q to Quit.");
+            ConsoleKeyInfo info;
+            do {
+                info = Console.ReadKey(intercept: true);
+            } while(info.Modifiers is not 0); // No modifiers
+            return info.Key is not ConsoleKey.Q; // Check for Enter confirmation
         }
 
         static void Usage()

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -1,0 +1,11 @@
+namespace MyAddressExtractor {
+    public static class Extensions {
+        public static void AddAll<TKey, TVal>(this IDictionary<TKey, TVal> dictionary, IEnumerable<TKey> keys, TVal value)
+        {
+            foreach (TKey key in keys)
+            {
+                dictionary[key] = value;
+            }
+        }
+    }
+}

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -57,7 +57,7 @@ namespace MyAddressExtractor {
                 var file = new FileInfo(path);
                 if (file.Extension is {Length: >0} extension)
                 {
-                    var info = infos.GetOrAdd(extension, _ => new ExtensionInfo(extension));
+                    var info = infos.GetOrAdd(extension, _ => new ExtensionInfo(extension.ToLower()));
                     info.AddFile(file);
                 }
             }
@@ -67,7 +67,7 @@ namespace MyAddressExtractor {
             Console.WriteLine($"Found {this.Files.Count:n0} files:");
             foreach (ExtensionInfo info in sorted)
             {
-                Console.WriteLine($"{info.Extension.ToLower()}: {info.Count} files : {info.Bytes} bytes{(info.Parsing.Read ? string.Empty : $", Skipping ({info.Parsing.Error})")}");
+                Console.WriteLine($"{info.Extension}: {info.Count} files : {info.Bytes} bytes{(info.Parsing.Read ? string.Empty : $", Skipping ({info.Parsing.Error})")}");
             }
         }
 

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -1,0 +1,99 @@
+using System.Collections;
+using System.Collections.Concurrent;
+
+namespace MyAddressExtractor {
+    internal sealed class FileCollection : IEnumerable<string>
+    {
+        private readonly ISet<string> Files;
+
+        public FileCollection(IEnumerable<string> inputs)
+        {
+            this.Files = this.CreateSystemSet();
+            this.Files.UnionWith(this.GatherFiles(inputs));
+            this.Log();
+        }
+
+        private IEnumerable<string> GatherFiles(IEnumerable<string> inputs)
+        {
+            foreach (string file in inputs) {
+                FileAttributes attributes = File.GetAttributes(file);
+                if (attributes.HasFlag(FileAttributes.Directory))
+                {
+                    foreach (string enumerated in Directory.EnumerateFiles(file))
+                    {
+                        yield return enumerated;
+                    }
+                }
+                else if (File.Exists(file))
+                {
+                    yield return file;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gather our <see cref="IEnumerable{String}"/> as a Set so that we don't have duplicates
+        /// Windows uses a Case-Insensitive File system, so on it we can mostly ignore casing
+        /// </summary>
+        private ISet<string> CreateSystemSet()
+        {
+            OperatingSystem os = Environment.OSVersion;
+            if (os.Platform is PlatformID.Win32S or PlatformID.Win32Windows or PlatformID.Win32NT or PlatformID.WinCE)
+            {
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            return new HashSet<string>();
+        }
+
+        private void Log()
+        {
+            var infos = new ConcurrentDictionary<string, ExtensionInfo>();
+            foreach (string path in this)
+            {
+                var file = new FileInfo(path);
+                if (file.Extension is {Length: >0} extension)
+                {
+                    var info = infos.GetOrAdd(extension, _ => new ExtensionInfo(extension));
+                    info.AddFile(file);
+                }
+            }
+
+            var sorted = infos.Values
+                .OrderBy(info => info.Parsing.Read ? -info.Count : 0);
+            Console.WriteLine($"Found {this.Files.Count:n0} files:");
+            foreach (ExtensionInfo info in sorted)
+            {
+                Console.WriteLine($"{info.Extension}: {info.Count} files : {info.Bytes} bytes{(info.Parsing.Read ? string.Empty : $", Skipping ({info.Parsing.Error})")}");
+            }
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<string> GetEnumerator()
+            => this.Files.GetEnumerator();
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator()
+            => this.GetEnumerator();
+
+        private class ExtensionInfo {
+            public readonly string Extension;
+            public readonly FileExtensionParsing Parsing;
+
+            public int Count { get; private set; }
+            public long Bytes { get; private set; }
+
+            public ExtensionInfo(string extension)
+            {
+                this.Extension = extension;
+                this.Parsing = FileExtensionParsing.Get(extension);
+            }
+
+            public void AddFile(FileInfo info)
+            {
+                this.Count++;
+                this.Bytes += info.Length;
+            }
+        }
+    }
+}

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -51,7 +51,7 @@ namespace MyAddressExtractor {
 
         private void Log()
         {
-            var infos = new ConcurrentDictionary<string, ExtensionInfo>();
+            var infos = new ConcurrentDictionary<string, ExtensionInfo>(StringComparer.OrdinalIgnoreCase);
             foreach (string path in this)
             {
                 var file = new FileInfo(path);
@@ -67,7 +67,7 @@ namespace MyAddressExtractor {
             Console.WriteLine($"Found {this.Files.Count:n0} files:");
             foreach (ExtensionInfo info in sorted)
             {
-                Console.WriteLine($"{info.Extension}: {info.Count} files : {info.Bytes} bytes{(info.Parsing.Read ? string.Empty : $", Skipping ({info.Parsing.Error})")}");
+                Console.WriteLine($"{info.Extension.ToLower()}: {info.Count} files : {info.Bytes} bytes{(info.Parsing.Read ? string.Empty : $", Skipping ({info.Parsing.Error})")}");
             }
         }
 

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -13,15 +13,18 @@ namespace MyAddressExtractor {
             this.Log();
         }
 
-        private IEnumerable<string> GatherFiles(IEnumerable<string> inputs)
+        private IEnumerable<string> GatherFiles(IEnumerable<string> inputs, bool recursed = false)
         {
             foreach (string file in inputs) {
                 FileAttributes attributes = File.GetAttributes(file);
                 if (attributes.HasFlag(FileAttributes.Directory))
                 {
-                    foreach (string enumerated in Directory.EnumerateFiles(file))
+                    if (!recursed || CommandLineProcessor.OPERATE_RECURSIVELY)
                     {
-                        yield return enumerated;
+                        foreach (string enumerated in this.GatherFiles(Directory.EnumerateFileSystemEntries(file), recursed: true))
+                        {
+                            yield return enumerated;
+                        }
                     }
                 }
                 else if (File.Exists(file))

--- a/src/FileExtensionParsing.cs
+++ b/src/FileExtensionParsing.cs
@@ -1,0 +1,80 @@
+using System.Collections.Concurrent;
+
+namespace MyAddressExtractor {
+    internal sealed class FileExtensionParsing
+    {
+        private static readonly IReadOnlyDictionary<string, FileExtensionParsing> FILE_EXTENSIONS;
+        private static readonly FileExtensionParsing UNKNOWN = new() { Error = "Unknown Extension" };
+        static FileExtensionParsing() {
+            var extensions = new ConcurrentDictionary<string, FileExtensionParsing>(StringComparer.OrdinalIgnoreCase);
+            
+            // Accepted plaintext files
+            extensions.AddAll(
+                new[] { ".log", ".json", ".txt", ".gcode", ".prproj", ".xml", ".sample", ".csv" },
+                new FileExtensionParsing() // No error means OK!
+            );
+            
+            // Archives
+            extensions.AddAll(
+                new[] { ".tar", ".gz", ".zip", ".rar", ".7z" },
+                new FileExtensionParsing { Error = "Archive files" }
+            );
+            
+            // Images
+            extensions.AddAll(
+                new[] { ".png", ".tif", ".jpg", ".jpeg", ".gif", ".bmp", ".ai", ".psd", ".svg", ".ico" },
+                new FileExtensionParsing { Error = "Image files" }
+            );
+            
+            // AudioVideo
+            extensions.AddAll(
+                new[] { ".rec", ".mp3", ".wav", ".mp4", ".mpg", ".mov", ".wmv", ".avi", ".m4v" },
+                new FileExtensionParsing { Error = "Audio/Video files" }
+            );
+            
+            // Sql
+            extensions.AddAll(
+                new[] { ".frm", ".ibd", ".myi", ".myd" },
+                new FileExtensionParsing { Error = "Sql files" }
+            );
+            
+            // Code
+            extensions.AddAll(
+                new[] { ".go", ".py", ".js", ".yml", ".php", ".c", ".sh", ".css", ".less", ".npmignore", ".groovy", ".scala", ".sass", ".ascx", ".markdown", ".bash", ".sln", ".h", ".ts", ".cs", ".aspx", ".csproj", ".nupk", ".suo", ".asax", ".resx", ".refesh", ".ipch" },
+                new FileExtensionParsing { Error = "Code files" }
+            );
+            
+            // Source Control
+            extensions.AddAll(
+                new[] { ".svn-base", ".gitignore", ".gitattributes", ".pack" },
+                new FileExtensionParsing { Error = "Source-control files" }
+            );
+            
+            // Executables
+            extensions.AddAll(
+                new[] { ".exe", ".dll", ".apk", ".jar", ".java",  "bin" },
+                new FileExtensionParsing { Error = "Executables" }
+            );
+            
+            // Other
+            extensions.AddAll(
+                new[] { ".msi", ".flv", ".swf", ".pdb", ".brd", ".hprof", ".lock", ".docker", ".ttf", ".woff", ".woff2", ".pem", ".crt" },
+                new FileExtensionParsing { Error = "Unsupported" }
+            );
+            
+            // Future
+            extensions.AddAll(
+                new[] { ".xls", ".doc", ".docx", ".ppt", ".pptx", ".pdf", ".rdb" },
+                new FileExtensionParsing { Error = "Not currently supported" }
+            );
+            
+            FileExtensionParsing.FILE_EXTENSIONS = extensions;
+        }
+
+        public static FileExtensionParsing Get(string extension)
+            => FileExtensionParsing.FILE_EXTENSIONS.GetValueOrDefault(extension, FileExtensionParsing.UNKNOWN);
+
+        public bool Read => this.Error is null;
+        public string? Error { get; init; } = null;
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -21,12 +21,10 @@ namespace MyAddressExtractor
         static async Task<int> Main(string[] args)
         {
             var inputFilePaths = new List<string>();
-            var outputFilePath = "addresses_output.txt";
-            var reportFilePath = "report.txt";
 
             try
             {
-                CommandLineProcessor.Process(args, inputFilePaths, ref outputFilePath, ref reportFilePath);
+                CommandLineProcessor.Process(args, inputFilePaths);
             }
             catch (ArgumentException ae)
             {
@@ -41,21 +39,22 @@ namespace MyAddressExtractor
 
             try
             {
+                var files = new FileCollection(inputFilePaths);
+
+                if (!CommandLineProcessor.WaitInput())
+                    return (int)ErrorCode.NoError;
+
                 await using (var monitor = new AddressExtractorMonitor())
                 {
-                    await monitor.RunAsync(inputFilePaths, CancellationToken.None);
+                    await monitor.RunAsync(files, CancellationToken.None);
 
                     // Log one last time out of the Timer loop
                     monitor.Log();
-                    await monitor.SaveAsync(
-                        outputFilePath,
-                        reportFilePath,
-                        CancellationToken.None
-                    );
+                    await monitor.SaveAsync(CancellationToken.None);
                 }
                 
-                Console.WriteLine($"Addresses saved to {outputFilePath}");
-                Console.WriteLine($"Report saved to {reportFilePath}");
+                Console.WriteLine($"Addresses saved to {CommandLineProcessor.OUTPUT_FILE_PATH}");
+                Console.WriteLine($"Report saved to {CommandLineProcessor.REPORT_FILE_PATH}");
             }
             catch (Exception ex)
             {

--- a/test/CommandLineProcessorTests.cs
+++ b/test/CommandLineProcessorTests.cs
@@ -11,8 +11,7 @@ namespace AddressExtractorTest
         {
             var args = Array.Empty<string>();
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -20,8 +19,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-o", "output" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -29,8 +27,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -38,8 +35,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-r" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -47,8 +43,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o", "-r", "report" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -56,8 +51,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-r", "-o", "output" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -65,8 +59,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -74,8 +67,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-z" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -83,8 +75,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-?" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
         }
 
         [TestMethod]
@@ -92,8 +83,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input", "-?" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -101,8 +91,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-?", "input" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -110,8 +99,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-v" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
         }
 
         [TestMethod]
@@ -119,8 +107,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input", "-v" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -128,8 +115,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-v", "input" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs, ref output, ref report));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
         }
 
         [TestMethod]
@@ -137,12 +123,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(output, string.Empty);
-            Assert.AreEqual(report, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
         }
 
         [TestMethod]
@@ -150,13 +135,12 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "input2" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[1]);
-            Assert.AreEqual(output, string.Empty);
-            Assert.AreEqual(report, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
         }
 
         [TestMethod]
@@ -164,12 +148,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o", "output" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(output, args[2]);
-            Assert.AreEqual(report, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[2]);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
         }
 
         [TestMethod]
@@ -177,12 +160,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-r", "report" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(output, string.Empty);
-            Assert.AreEqual(report, args[2]);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, args[2]);
         }
 
         [TestMethod]
@@ -190,12 +172,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o", "output", "-r", "report" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(output, args[2]);
-            Assert.AreEqual(report, args[4]);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[2]);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, args[4]);
         }
 
         [TestMethod]
@@ -203,12 +184,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-r", "report", "-o", "output" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(output, args[4]);
-            Assert.AreEqual(report, args[2]);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[4]);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, args[2]);
         }
 
         [TestMethod]
@@ -216,13 +196,12 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "input2", "-o", "output" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[1]);
-            Assert.AreEqual(output, args[3]);
-            Assert.AreEqual(report, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[3]);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
         }
 
         [TestMethod]
@@ -230,13 +209,12 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o", "output", "input2" };
             var inputs = new List<string>();
-            string output = string.Empty, report = string.Empty;
-            CommandLineProcessor.Process(args, inputs, ref output, ref report);
+            CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[3]);
-            Assert.AreEqual(output, args[2]);
-            Assert.AreEqual(report, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[2]);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
         }
     }
 }


### PR DESCRIPTION
As requested in #21 I've added file scanning. If the path that is inputted is a Directory instead of a File it will loop over that directory.

----

I also created a `--recursive` flag (`-r` was taken by the report function so I made it explicit) which will enter child directories as well to search for files.

I didn't want to try and adding a complex function to math from bytes to MB as you have listed in your example

    Found 402 files:
    .log : 90 files : 3,255,102MB
    .json : 47 files : 1,091,043MB
    .txt : 32 files : 76,496,578MB
    .gcode : 27 files : 44,729MB
    .prproj : 27 files : 2,077MB
    .XML : 26 files : 44MB
    .sample : 24 files : 40MB
    .csv : 17 files : 261,774MB

I did also take the `Ready?` from your example and add a prompt before beginning to read the files. It reads **Press ANY KEY to continue. Q to Quit.**

----

I also changed how the CommandLine parser returns its inputted save-paths, to store them as a static reference instead of having to pass them around everywhere for saving. Just as a bit of a cleanup