### PR TITLE
Fix incorrect handling of commas

### DIFF
--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -6,7 +6,7 @@ namespace MyAddressExtractor
 {
     public partial class AddressExtractor
     {
-        [GeneratedRegex(@"[a-z0-9\.\-!#$%&'+-/=?^_`{|}~""\\]+(?<!\.)@([a-z0-9\-_]+\.)+[a-z0-9]{2,}\b(?<!\s)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled)]
+        [GeneratedRegex(@"[a-z0-9\.\-!#$%&'+/=?^_`{|}~""\\]+(?<!\.)@([a-z0-9\-_]+\.)+[a-z0-9]{2,}\b(?<!\s)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled)]
         public static partial Regex EmailRegex();
         
         public async IAsyncEnumerable<string> ExtractAddressesFromFileAsync(string inputFilePath, [EnumeratorCancellation] CancellationToken cancellation = default)


### PR DESCRIPTION
This should resolve #22. This was caused by an error in the regex, where the character set ``!#$%&'*+-/=?^_`{|}~`` was put into the regex but the `-` character wasn't escaped, instead causing it to be the *range* of characters between `+` and `/`, which includes `,`. 

Screenshot from RegExr:
![firefox_y3ZQObFm0Z](https://user-images.githubusercontent.com/15311130/233964347-d4164996-6f9f-41ec-9730-995c84bf064c.png)

Since `-` is already included as a character, I've removed it between `+` and `/` and the test now passes.
