### PR TITLE
Fix for FileCollections

### DIFF
--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -52,6 +52,7 @@ namespace MyAddressExtractor {
         private void Log()
         {
             var infos = new ConcurrentDictionary<string, ExtensionInfo>(StringComparer.OrdinalIgnoreCase);
+            var count = this.Files.Count; // Cache the count before removing
             foreach (string path in this)
             {
                 var file = new FileInfo(path);
@@ -59,12 +60,18 @@ namespace MyAddressExtractor {
                 {
                     var info = infos.GetOrAdd(extension, _ => new ExtensionInfo(extension.ToLower()));
                     info.AddFile(file);
+                    
+                    // Remove ignored files
+                    if (!info.Parsing.Read)
+                    {
+                        this.Files.Remove(path);
+                    }
                 }
             }
 
             var sorted = infos.Values
                 .OrderBy(info => info.Parsing.Read ? -info.Count : 0);
-            Console.WriteLine($"Found {this.Files.Count:n0} files:");
+            Console.WriteLine($"Found {count:n0} files:");
             foreach (ExtensionInfo info in sorted)
             {
                 Console.WriteLine($"{info.Extension}: {info.Count} files : {info.Bytes} bytes{(info.Parsing.Read ? string.Empty : $", Skipping ({info.Parsing.Error})")}");
@@ -73,11 +80,7 @@ namespace MyAddressExtractor {
 
         /// <inheritdoc />
         public IEnumerator<string> GetEnumerator()
-            => this.Files.Where(file => {
-                var info = new FileInfo(file);
-                return info.Extension is {Length: >0}
-                    && FileExtensionParsing.Get(info.Extension).Read;
-            }).GetEnumerator();
+            => this.Files.GetEnumerator();
 
         /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -73,7 +73,11 @@ namespace MyAddressExtractor {
 
         /// <inheritdoc />
         public IEnumerator<string> GetEnumerator()
-            => this.Files.GetEnumerator();
+            => this.Files.Where(file => {
+                var info = new FileInfo(file);
+                return info.Extension is {Length: >0}
+                    && FileExtensionParsing.Get(info.Extension).Read;
+            }).GetEnumerator();
 
         /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
Realized after implementing #24 that I had used filtering for the logging of which extensions to use and ignore, but when calling the iterator that it wasn't actually excluding bad extensions.