### PR TITLE
Fixes to the tests

### DIFF
--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -5,10 +5,10 @@ namespace MyAddressExtractor
 {
     internal static class CommandLineProcessor
     {
-        public static string OUTPUT_FILE_PATH { get; private set; } = "addresses_output.txt";
-        public static string REPORT_FILE_PATH { get; private set; } = "report.txt";
+        public static string OUTPUT_FILE_PATH { get; private set; } = Defaults.OUTPUT_FILE_PATH;
+        public static string REPORT_FILE_PATH { get; private set; } = Defaults.REPORT_FILE_PATH;
 
-        public static bool OPERATE_RECURSIVELY { get; private set; } = false;
+        public static bool OPERATE_RECURSIVELY { get; private set; } = Defaults.OPERATE_RECURSIVELY;
 
         internal static void Process(string[] args, IList<string> inputFilePaths)
         {
@@ -137,6 +137,13 @@ namespace MyAddressExtractor
         {
             var assembly = Assembly.GetExecutingAssembly();
             Console.WriteLine(assembly.GetName().Version);
+        }
+        
+        public static class Defaults {
+            public const string OUTPUT_FILE_PATH = "addresses_output.txt";
+            public const string REPORT_FILE_PATH = "report.txt";
+            
+            public const bool OPERATE_RECURSIVELY = false;
         }
     }
 }

--- a/test/CommandLineProcessorTests.cs
+++ b/test/CommandLineProcessorTests.cs
@@ -126,8 +126,8 @@ namespace AddressExtractorTest
             CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, string.Empty);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -139,8 +139,8 @@ namespace AddressExtractorTest
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[1]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, string.Empty);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -152,7 +152,7 @@ namespace AddressExtractorTest
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[2]);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -163,7 +163,7 @@ namespace AddressExtractorTest
             CommandLineProcessor.Process(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
             Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, args[2]);
         }
 
@@ -201,7 +201,7 @@ namespace AddressExtractorTest
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[1]);
             Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[3]);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -214,7 +214,7 @@ namespace AddressExtractorTest
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[3]);
             Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[2]);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, string.Empty);
+            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
     }
 }


### PR DESCRIPTION
Created constants for the tests where input arguments *are not* passed. The default fallback values were not being used for the Tests and `string.Empty` was being used, causing failures