### PR TITLE
Changed CLI config to non-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Syntax: `AddressExtractor.exe -?`
 Syntax: `AddressExtractor.exe -v`
 Syntax: `AddressExtractor.exe <input [[... input]]> [-o output] [-r report]`
 
-| Option | Description |
-| ------ | ----------- |
-| -? | Prints the command line syntax and options |
-| -v | Prints the application version number |
-| input  | One or more input filenames |
-| -o output | Path and filename of the output file. Defaults to 'addresses_output.txt' |
-| -r report | Path and filename of the report file. Defaults to 'report.txt' |
-
+| Option                  | Description                                                                |
+|-------------------------|----------------------------------------------------------------------------|
+| `-?`, `-h`, `--help`    | Prints the command line syntax and options                                 |
+| `-v`, `--version`       | Prints the application version number                                      |
+| input                   | One or more input filenames or directories                                 |
+| `-o`, `--output` output | Path and filename of the output file. Defaults to 'addresses_output.txt'   |
+| `-r`, `--report` report | Path and filename of the report file. Defaults to 'report.txt'             |
+| `--recursive`           | Enable recursive mode for directories, which will search child directories |
+| `-y`, `--yes`           | Automatically confirm prompts to CONTINUE without asking                   |

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -26,34 +26,40 @@ namespace MyAddressExtractor
             }
         }
 
-        public IEnumerable<string> ExtractAddresses(string content)
+        public IEnumerable<string> ExtractAddresses(string? content)
         {
+            if (content is null)
+            {
+                yield break;
+            }
+
             var matches = AddressExtractor.EmailRegex()
                 .Matches(content);
 
             foreach (Match match in matches) {
                 string email = match.Value;
 
+                if (email.StartsWith('.'))
+                    continue;
+                if (email.Length >= 256)
+                    continue;
                 if (email.Contains('*'))
                     continue;
                 if (email.Contains(".."))
                     continue;
                 if (email.Contains(".@"))
                     continue;
-                if (email.Length >= 256)
+                var domain = email[email.LastIndexOf('@')..];
+                // Handle cases such as: foo@bar.1com, foo@bar.12com
+                if (char.IsNumber(domain[domain.LastIndexOf('.')+1]))
                     continue;
                 // Handle cases such as: foobar@_.com, oobar@f_b.com
-                if (email[email.LastIndexOf('@')..].Contains('_'))
-                    continue;
-                // Handle cases such as: foo@bar.1com, foo@bar.12com
-                if (int.TryParse(email[email.LastIndexOf('.')+1].ToString(), out _))
-                    continue;
-                if (email.StartsWith("."))
+                if (domain.Contains('_'))
                     continue;
                  // Handle cases such as: username@-example-.com , username@-example.com and username@example-.com
-                if (email.Contains("@-") || email[email.LastIndexOf('@')..].Contains("-."))
+                if (email.Contains("@-") || domain.Contains("-."))
                     continue;
-                    
+
                 yield return email;
             }
         }

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -43,10 +43,10 @@ namespace MyAddressExtractor {
             Console.WriteLine($"Read lines rate: {rate:n0}/s\n");
         }
 
-        public async ValueTask SaveAsync(CancellationToken cancellation = default)
+        internal async ValueTask SaveAsync(CommandLineProcessor cli, CancellationToken cancellation = default)
         {
-            string output = CommandLineProcessor.OUTPUT_FILE_PATH;
-            string report = CommandLineProcessor.REPORT_FILE_PATH;
+            string output = cli.OutputFilePath;
+            string report = cli.ReportFilePath;
             if (!string.IsNullOrWhiteSpace(output))
             {
                 await this.Extractor.SaveAddressesAsync(output, this.Addresses, cancellation);

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -4,10 +4,14 @@ using System.Collections.Concurrent;
 namespace MyAddressExtractor {
     internal sealed class FileCollection : IEnumerable<string>
     {
+        private readonly CommandLineProcessor Cli;
         private readonly ISet<string> Files;
 
-        public FileCollection(IEnumerable<string> inputs)
+        public int Count => this.Files.Count;
+
+        public FileCollection(CommandLineProcessor cli, IEnumerable<string> inputs)
         {
+            this.Cli = cli;
             this.Files = this.CreateSystemSet();
             this.Files.UnionWith(this.GatherFiles(inputs));
             this.Log();
@@ -19,7 +23,7 @@ namespace MyAddressExtractor {
                 FileAttributes attributes = File.GetAttributes(file);
                 if (attributes.HasFlag(FileAttributes.Directory))
                 {
-                    if (!recursed || CommandLineProcessor.OPERATE_RECURSIVELY)
+                    if (!recursed || this.Cli.OperateRecursively)
                     {
                         foreach (string enumerated in this.GatherFiles(Directory.EnumerateFileSystemEntries(file), recursed: true))
                         {
@@ -74,7 +78,7 @@ namespace MyAddressExtractor {
             Console.WriteLine($"Found {count:n0} files:");
             foreach (ExtensionInfo info in sorted)
             {
-                Console.WriteLine($"{info.Extension}: {info.Count:n0} files : {info.Bytes:n0} bytes{(info.Parsing.Read ? string.Empty : $", Skipping ({info.Parsing.Error})")}");
+                Console.WriteLine($"- {info.Extension}: {info.Count:n0} files : {info.Bytes:n0} bytes{(info.Parsing.Read ? string.Empty : $", Skipping ({info.Parsing.Error})")}");
             }
         }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -22,9 +22,10 @@ namespace MyAddressExtractor
         {
             var inputFilePaths = new List<string>();
 
+            CommandLineProcessor config;
             try
             {
-                CommandLineProcessor.Process(args, inputFilePaths);
+                config = new CommandLineProcessor(args, inputFilePaths);
             }
             catch (ArgumentException ae)
             {
@@ -39,9 +40,9 @@ namespace MyAddressExtractor
 
             try
             {
-                var files = new FileCollection(inputFilePaths);
+                var files = new FileCollection(config, inputFilePaths);
 
-                if (!CommandLineProcessor.WaitInput())
+                if (!config.WaitInput(files))
                     return (int)ErrorCode.NoError;
 
                 await using (var monitor = new AddressExtractorMonitor())
@@ -50,11 +51,11 @@ namespace MyAddressExtractor
 
                     // Log one last time out of the Timer loop
                     monitor.Log();
-                    await monitor.SaveAsync(CancellationToken.None);
+                    await monitor.SaveAsync(config, CancellationToken.None);
                 }
                 
-                Console.WriteLine($"Addresses saved to {CommandLineProcessor.OUTPUT_FILE_PATH}");
-                Console.WriteLine($"Report saved to {CommandLineProcessor.REPORT_FILE_PATH}");
+                Console.WriteLine($"Addresses saved to {config.OutputFilePath}");
+                Console.WriteLine($"Report saved to {config.ReportFilePath}");
             }
             catch (Exception ex)
             {

--- a/test/CommandLineProcessorTests.cs
+++ b/test/CommandLineProcessorTests.cs
@@ -11,7 +11,7 @@ namespace AddressExtractorTest
         {
             var args = Array.Empty<string>();
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -19,7 +19,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-o", "output" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -27,7 +27,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-r" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -43,7 +43,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o", "-r", "report" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -51,7 +51,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-r", "-o", "output" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -59,7 +59,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -67,7 +67,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-z" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -75,7 +75,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-?" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
         }
 
         [TestMethod]
@@ -83,7 +83,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input", "-?" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -91,7 +91,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-?", "input" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -99,7 +99,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-v" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
         }
 
         [TestMethod]
@@ -107,7 +107,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input", "-v" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -115,7 +115,7 @@ namespace AddressExtractorTest
         {
             var args = new[] { "-v", "input" };
             var inputs = new List<string>();
-            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Process(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
         }
 
         [TestMethod]
@@ -123,11 +123,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.OutputFilePath, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
+            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -135,12 +135,12 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "input2" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[1]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.OutputFilePath, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
+            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -148,11 +148,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o", "output" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[2]);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.OutputFilePath, args[2]);
+            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -160,11 +160,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-r", "report" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, args[2]);
+            Assert.AreEqual(config.OutputFilePath, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
+            Assert.AreEqual(config.ReportFilePath, args[2]);
         }
 
         [TestMethod]
@@ -172,11 +172,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o", "output", "-r", "report" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[2]);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, args[4]);
+            Assert.AreEqual(config.OutputFilePath, args[2]);
+            Assert.AreEqual(config.ReportFilePath, args[4]);
         }
 
         [TestMethod]
@@ -184,11 +184,11 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-r", "report", "-o", "output" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[4]);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, args[2]);
+            Assert.AreEqual(config.OutputFilePath, args[4]);
+            Assert.AreEqual(config.ReportFilePath, args[2]);
         }
 
         [TestMethod]
@@ -196,12 +196,12 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "input2", "-o", "output" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[1]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[3]);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.OutputFilePath, args[3]);
+            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -209,12 +209,12 @@ namespace AddressExtractorTest
         {
             var args = new[] { "input1", "-o", "output", "input2" };
             var inputs = new List<string>();
-            CommandLineProcessor.Process(args, inputs);
+            var config = new CommandLineProcessor(args, inputs);
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[3]);
-            Assert.AreEqual(CommandLineProcessor.OUTPUT_FILE_PATH, args[2]);
-            Assert.AreEqual(CommandLineProcessor.REPORT_FILE_PATH, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.OutputFilePath, args[2]);
+            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
     }
 }

--- a/test/LegacyTests.cs
+++ b/test/LegacyTests.cs
@@ -3,122 +3,158 @@ using MyAddressExtractor;
 
 namespace AddressExtractorTest
 {
-  [TestClass]
-  public class LegacyTests
-  {
-    // Valid addresses
-
-    [TestMethod]
-    public void ampersand_is_valid() { Assert.IsTrue(IsValidEmail(@"Mary&Jane@example.org")); }
-
-    [TestMethod]
-    public void single_backslash_enclosed_in_quotes_is_valid() { Assert.IsTrue(IsValidEmail(@"""test\""blah""@example.com")); }
-
-    [TestMethod]
-    public void forward_slash_is_valid() { Assert.IsTrue(IsValidEmail(@"customer/department@example.com")); }
-
-    [TestMethod]
-    public void starting_with_dollar_sign_is_valid() { Assert.IsTrue(IsValidEmail(@"$A12345@example.com")); }
-
-    [TestMethod]
-    public void starting_with_exclamation_mark_is_valid() { Assert.IsTrue(IsValidEmail(@"!def!xyz%abc@example.com")); }
-
-    [TestMethod]
-    public void starting_with_underscore_is_valid() { Assert.IsTrue(IsValidEmail(@"_Yosemite.Sam@example.com")); }
-
-    [TestMethod]
-    public void dot_in_alias_is_valid() { Assert.IsTrue(IsValidEmail(@"Ima.Fool@example.com")); }
-
-    [TestMethod]
-    public void single_char_domain_is_valid() { Assert.IsTrue(IsValidEmail(@"foobar@x.com")); }
-
-    [TestMethod]
-    public void domain_with_number_is_valid() { Assert.IsTrue(IsValidEmail(@"foobar@c0m.com")); }
-
-    [TestMethod]
-    public void domain_with_underscore_is_valid() { Assert.IsTrue(IsValidEmail(@"foobar@c_m.com")); }
-
-    [TestMethod]
-    public void domain_with_underscore_before_tld_is_valid() { Assert.IsTrue(IsValidEmail(@"foo@bar_.com")); }
-
-    [TestMethod]
-    public void domain_with_numbers_only_is_valid() { Assert.IsTrue(IsValidEmail(@"foo@666.com")); }
-
-    [TestMethod]
-    public void email_of_255_chars_is_valid() { Assert.IsTrue(IsValidEmail(@"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com")); }
-
-    // Invalid addresses
-
-    [TestMethod]
-    public void null_is_invalid() { Assert.IsFalse(IsValidEmail(null)); }
-
-    [TestMethod]
-    public void empty_email_is_invalid() { Assert.IsFalse(IsValidEmail(string.Empty)); }
-
-    [TestMethod]
-    public void no_at_symbol_is_invalid() { Assert.IsFalse(IsValidEmail("NotAnEmail")); }
-
-    [TestMethod]
-    public void at_first_is_invalid() { Assert.IsFalse(IsValidEmail("@NotAnEmail")); }
-
-    [TestMethod]
-    public void at_last_is_invalid() { Assert.IsFalse(IsValidEmail("NotAnEmail@")); }
-
-    [TestMethod]
-    public void backspace_char_is_invalid() { Assert.IsFalse(IsValidEmail("foo@b" + (char)8 + "ar.com")); }
-
-    [TestMethod]
-    public void horizontal_tab_char_is_invalid() { Assert.IsFalse(IsValidEmail("foo@b" + (char)9 + "ar.com")); }
-
-    [TestMethod]
-    public void delete_char_is_invalid() { Assert.IsFalse(IsValidEmail("foo@b" + (char)127 + "ar.com")); }
-
-    [TestMethod]
-    public void alias_with_asterisk_is_invalid() { Assert.IsFalse(IsValidEmail(@"fo*o@bar.com")); }
-
-    [TestMethod]
-    public void email_of_256_chars_is_invalid() { Assert.IsFalse(IsValidEmail(@"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com")); }
-
-    [TestMethod]
-    public void unescaped_double_quote_is_invalid() { Assert.IsFalse(IsValidEmail("\"test\rblah\"@example.com")); }
-
-    [TestMethod]
-    public void dot_first_is_invalid() { Assert.IsFalse(IsValidEmail(@".wooly@example.com")); }
-
-    [TestMethod]
-    public void consecutive_dots_is_invalid() { Assert.IsFalse(IsValidEmail(@"wo..oly@example.com")); }
-
-    [TestMethod]
-    public void dot_before_at_is_invalid() { Assert.IsFalse(IsValidEmail(@"pootietang.@example.com")); }
-
-    [TestMethod]
-    public void dot_for_alias_is_invalid() { Assert.IsFalse(IsValidEmail(@".@example.com")); }
-
-    [TestMethod]
-    public void no_dot_in_domain_is_invalid() { Assert.IsFalse(IsValidEmail(@"foo@bar")); }
-
-    [TestMethod]
-    public void tld_starting_with_number_is_not_valid() { Assert.IsFalse(IsValidEmail("foo@bar.1com")); }
-    
-    [TestMethod]
-    public void tld_with_only_numbers_is_not_valid() { Assert.IsFalse(IsValidEmail("foo@bar.123")); }   
-    
-    [TestMethod]
-    public void tld_with_one_character_is_not_valid() { Assert.IsFalse(IsValidEmail("foo@bar.a")); }
-
-    [TestMethod]
-    public void domain_with_underscore_only_is_not_valid() { Assert.IsFalse(IsValidEmail(@"foobar@_.com")); }
-
-    /// <summary>
-    /// Purely added to make it easy to include the legacy tests, ideally should be removed in favour of more verbose test syntax
-    /// </summary>
-    /// <param name="sourceEmail"></param>
-    /// <returns></returns>
-    private bool IsValidEmail(string sourceEmail)
+    [TestClass]
+    public class LegacyTests
     {
-      var sut = new AddressExtractor();
-      var result = sut.ExtractAddresses(sourceEmail);
-      return result.Any();
+        #region Valid addresses
+
+        [TestMethod]
+        public void AmpersandIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"Mary&Jane@example.org"));
+
+        [TestMethod]
+        public void SingleBackslashEnclosedInQuotesIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"""test\""blah""@example.com"));
+
+        [TestMethod]
+        public void ForwardSlashIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"customer/department@example.com"));
+
+        [TestMethod]
+        public void StartingWithDollarSignIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"$A12345@example.com"));
+
+        [TestMethod]
+        public void StartingWithExclamationMarkIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"!def!xyz%abc@example.com"));
+
+        [TestMethod]
+        public void StartingWithUnderscoreIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"_Yosemite.Sam@example.com"));
+
+        [TestMethod]
+        public void DotInAliasIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"Ima.Fool@example.com"));
+
+        [TestMethod]
+        public void SingleCharDomainIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"foobar@x.com"));
+
+        [TestMethod]
+        public void DomainWithNumberIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"foobar@c0m.com"));
+
+        [TestMethod]
+        public void DomainWithUnderscoreIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"foobar@c_m.com"));
+
+        [TestMethod]
+        public void DomainWithUnderscoreBeforeTldIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"foo@bar_.com"));
+
+        [TestMethod]
+        public void DomainWithNumbersOnlyIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"foo@666.com"));
+
+        [TestMethod]
+        public void EmailOf255CharsIsValid()
+            => Assert.IsTrue(this.IsValidEmail(@"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com"));
+
+        #endregion
+        #region Invalid addresses
+
+        [TestMethod]
+        public void NullIsInvalid()
+        => Assert.IsFalse(this.IsValidEmail(null));
+
+        [TestMethod]
+        public void EmptyEmailIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail(string.Empty));
+
+        [TestMethod]
+        public void NoAtSymbolIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail("NotAnEmail"));
+
+        [TestMethod]
+        public void AtFirstIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail("@NotAnEmail"));
+
+        [TestMethod]
+        public void AtLastIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail("NotAnEmail@"));
+
+        [TestMethod]
+        public void BackspaceCharIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail("foo@b" + (char)8 + "ar.com"));
+
+        [TestMethod]
+        public void HorizontalTabCharIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail("foo@b" + (char)9 + "ar.com"));
+
+        [TestMethod]
+        public void DeleteCharIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail("foo@b" + (char)127 + "ar.com"));
+
+        [TestMethod]
+        public void AliasWithAsteriskIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail(@"fo*o@bar.com"));
+
+        [TestMethod]
+        public void EmailOf256CharsIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail(@"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com"));
+
+        [TestMethod]
+        public void UnescapedDoubleQuoteIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail("\"test\rblah\"@example.com"));
+
+        [TestMethod]
+        public void DotFirstIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail(@".wooly@example.com"));
+
+        [TestMethod]
+        public void ConsecutiveDotsIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail(@"wo..oly@example.com"));
+
+        [TestMethod]
+        public void DotBeforeAtIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail(@"pootietang.@example.com"));
+
+        [TestMethod]
+        public void DotForAliasIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail(@".@example.com"));
+
+        [TestMethod]
+        public void NoDotInDomainIsInvalid()
+            => Assert.IsFalse(this.IsValidEmail(@"foo@bar"));
+
+        [TestMethod]
+        public void TldStartingWithNumberIsNotValid()
+            => Assert.IsFalse(this.IsValidEmail("foo@bar.1com"));
+
+        [TestMethod]
+        public void TldWithOnlyNumbersIsNotValid()
+            => Assert.IsFalse(this.IsValidEmail("foo@bar.123"));
+
+        [TestMethod]
+        public void TldWithOneCharacterIsNotValid()
+            => Assert.IsFalse(this.IsValidEmail("foo@bar.a"));
+
+        [TestMethod]
+        public void DomainWithUnderscoreOnlyIsNotValid()
+            => Assert.IsFalse(this.IsValidEmail(@"foobar@_.com"));
+
+        #endregion
+
+        /// <summary>
+        /// Purely added to make it easy to include the legacy tests, ideally should be removed in favour of more verbose test syntax
+        /// </summary>
+        /// <param name="sourceEmail"></param>
+        /// <returns></returns>
+        private bool IsValidEmail(string? sourceEmail)
+        {
+            var sut = new AddressExtractor();
+            var result = sut.ExtractAddresses(sourceEmail);
+            return result.Any();
+        }
     }
-  }
 }

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -1,140 +1,142 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MyAddressExtractor;
 
-[TestClass]
-public class MyAddressExtractorTest
+namespace AddressExtractorTest
 {
-    [TestMethod]
-    public async Task correct_number_of_addresses_are_extracted_from_file()
+    [TestClass]
+    public class MyAddressExtractorTest
     {
-        // Act
-        var result = await this.ExtractAddressesFromFileAsync(@"../../../../TestData/SingleFile/SingleSmallFile.txt");
+        [TestMethod]
+        public async Task CorrectNumberOfAddressesAreExtractedFromFile()
+        {
+            var result = await this.ExtractAddressesFromFileAsync(@"../../../../TestData/SingleFile/SingleSmallFile.txt");
 
-        // Assert
-        Assert.IsTrue(result.Count == 12, "Parsing should pass");
-    }  
-    
-    [TestMethod]
-    public void email_addresses_are_not_case_sensitive()
-    {
-        const string addresses = "test@example.com TEST@EXAMPLE.COM";
+            // Assert
+            Assert.IsTrue(result.Count == 12, "Parsing should pass");
+        }
 
-        // Act
-        var result = this.ExtractAddresses(addresses);
+        [TestMethod]
+        public void EmailAddressesAreNotCaseSensitive()
+        {
+            const string ADDRESSES = "test@example.com TEST@EXAMPLE.COM";
 
-        // Assert
-        Assert.IsTrue(result.Count == 1, "Same addresses of different case should be merged");
+            // Act
+            var result = this.ExtractAddresses(ADDRESSES);
+
+            // Assert
+            Assert.IsTrue(result.Count == 1, "Same addresses of different case should be merged");
+        }
+
+        [TestMethod]
+        public void EmailAddressesAreConvertedToLowercase()
+        {
+            // Arrange
+            const string INPUT = "TEST@EXAMPLE.COM";
+            const string EXPECTED = "test@example.com";
+
+            // Act
+            var result = this.ExtractAddresses(INPUT);
+
+            result.Add(EXPECTED);
+
+            // Assert
+            Assert.IsTrue(result.Count == 1, "Address should always be converted to lowercase");
+        } 
+
+        [TestMethod]
+        public void EmailAddressesCannotHaveDomainStartingWithHyphen()
+        {
+            // Arrange
+            const string INPUT = "test@-example.com";
+
+            // Act
+            var result = this.ExtractAddresses(INPUT);
+
+            // Assert
+            Assert.IsFalse(result.Any(), "No results should be returned");
+        }    
+
+        [TestMethod]
+        public void EmailAddressesCannotHaveDomainEndingWithHyphen()
+        {
+            // Arrange
+            const string INPUT = "test@example-.com";
+
+            // Act
+            var result = this.ExtractAddresses(INPUT);
+
+            // Assert
+            Assert.IsFalse(result.Any(), "No results should be returned");
+        }
+
+        [TestMethod]
+        public void CommaShouldTerminateAddress()
+        {
+            // Arrange
+            const string INPUT = "email1@example.com,email2@example.com";
+            const string EXPECTED_FIRST = "email1@example.com";
+            const string EXPECTED_LAST = "email2@example.com";
+
+            // Act
+            var result = this.ExtractAddresses(INPUT);
+
+            // Assert
+            Assert.IsTrue(result.Count == 2, "Two results should be returned");
+            Assert.AreEqual(EXPECTED_FIRST, result.First(), $"First email address must be {EXPECTED_FIRST}");
+            Assert.AreEqual(EXPECTED_LAST, result.Last(), $"Last email address must be {EXPECTED_LAST}");
+        }
+
+        [TestMethod]
+        public void AliasOnEmojiDomainIsFound()
+        {
+          // Arrange
+          const string INPUT = "example@i❤️.ws is";
+
+          // Act
+          var result = this.ExtractAddresses(INPUT);
+
+          // Assert
+          Assert.IsTrue(result.Any(), "A result should be returned");
+        }
+
+        [TestMethod]
+        public void EmailAddressOnIdnDomainNameIsRecognised()
+        {
+          // Arrange
+          const string INPUT = "بريد@موقع.شبكة";
+
+          // Act
+          var result = this.ExtractAddresses(INPUT);
+
+          // Assert
+          Assert.IsTrue(result.Any(), "A result should be returned");
+        }
+
+        #region Wrappers
+
+        /// <summary>
+        /// Extract the addresses from the Address Extractor and wrap it into a set
+        /// Wrapping the <see cref="IEnumerable{String}"/> here instead of within the Method
+        /// prevents the overhead of creating a Set for every iteration in Production
+        /// </summary>
+        private HashSet<string> ExtractAddresses(string input)
+        {
+            var extractor = new AddressExtractor();
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            set.UnionWith(extractor.ExtractAddresses(input));
+            return set;
+        }
+
+        private async ValueTask<HashSet<string>> ExtractAddressesFromFileAsync(string path, CancellationToken cancellation = default)
+        {
+            // Arrange
+            var extractor = new AddressExtractor();
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            await foreach(var address in extractor.ExtractAddressesFromFileAsync(path, cancellation))
+                set.Add(address);
+            return set;
+        }
+
+        #endregion
     }
-    
-    [TestMethod]
-    public void email_addresses_are_converted_to_lowercase()
-    {
-        // Arrange
-        const string input = "TEST@EXAMPLE.COM";
-        const string expected = "test@example.com";
-
-        // Act
-        var result = this.ExtractAddresses(input);
-
-        result.Add(expected);
-
-        // Assert
-        Assert.IsTrue(result.Count == 1, "Address should always be converted to lowercase");
-    } 
-    
-    [TestMethod]
-    public void email_addresses_cannot_have_domain_starting_with_hyphen()
-    {
-        // Arrange
-        const string input = "test@-example.com";
-
-        // Act
-        var result = this.ExtractAddresses(input);
-
-        // Assert
-        Assert.IsFalse(result.Any(), "No results should be returned");
-    }    
-
-    [TestMethod]
-    public void email_addresses_cannot_have_domain_ending_with_hyphen()
-    {
-        // Arrange
-        const string input = "test@example-.com";
-
-        // Act
-        var result = this.ExtractAddresses(input);
-
-        // Assert
-        Assert.IsFalse(result.Any(), "No results should be returned");
-    }
-
-    [TestMethod]
-    public void comma_should_terminate_address()
-    {
-        // Arrange
-        const string input = "email1@example.com,email2@example.com";
-        const string expectedFirst = "email1@example.com";
-        const string expectedLast = "email2@example.com";
-
-        // Act
-        var result = this.ExtractAddresses(input);
-
-        // Assert
-        Assert.IsTrue(result.Count == 2, "Two results should be returned");
-        Assert.AreEqual(expectedFirst, result.First(), $"First email address must be {expectedFirst}");
-        Assert.AreEqual(expectedLast, result.Last(), $"Last email address must be {expectedLast}");
-    }
-
-    [TestMethod]
-    public void alias_on_emoji_domain_is_found()
-    {
-      // Arrange
-      const string input = "example@i❤️.ws is";
-
-      // Act
-      var result = this.ExtractAddresses(input);
-
-      // Assert
-      Assert.IsTrue(result.Any(), "A result should be returned");
-    }
-
-    [TestMethod]
-    public void email_address_on_idn_domain_name_is_recognised()
-    {
-      // Arrange
-      const string input = "بريد@موقع.شبكة";
-
-      // Act
-      var result = this.ExtractAddresses(input);
-
-      // Assert
-      Assert.IsTrue(result.Any(), "A result should be returned");
-    }
-
-    #region Wrappers
-    
-    /// <summary>
-    /// Extract the addresses from the Address Extractor and wrap it into a set
-    /// Wrapping the <see cref="IEnumerable{String}"/> here instead of within the Method
-    /// prevents the overhead of creating a Set for every iteration in Production
-    /// </summary>
-    private HashSet<string> ExtractAddresses(string input)
-    {
-        var extractor = new AddressExtractor();
-        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        set.UnionWith(extractor.ExtractAddresses(input));
-        return set;
-    }
-
-    private async ValueTask<HashSet<string>> ExtractAddressesFromFileAsync(string path, CancellationToken cancellation = default)
-    {
-        // Arrange
-        var extractor = new AddressExtractor();
-        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        await foreach(var address in extractor.ExtractAddressesFromFileAsync(path, cancellation))
-            set.Add(address);
-        return set;
-    }
-
-    #endregion
 }


### PR DESCRIPTION
All tests will now pass when simultaneously run

Added a "-y" or "--yes" parameter to automatically skip the CONTINUE? prompt
Added an `I` (for Info) keypress to the CONTINUE? prompt which will print all the files that are going to be read
Now accepts both short-form and long-form CLI parameters: (`-?`, `-h`, `--help`), (`-v`, `--version`), (`-o`, `--output`), (`-r`, `--report`)
Updated the README to reflect these changes