### PR TITLE
Implements a performance tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ Syntax: `AddressExtractor.exe <input [[... input]]> [-o output] [-r report]`
 | `-r`, `--report` report | Path and filename of the report file. Defaults to 'report.txt'             |
 | `--recursive`           | Enable recursive mode for directories, which will search child directories |
 | `-y`, `--yes`           | Automatically confirm prompts to CONTINUE without asking                   |
+| `--debug`               | Enabled debug mode for fine-tuned performance checking                     |

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -46,10 +46,10 @@ namespace MyAddressExtractor
 
         private IEnumerable<string> ExtractAddresses(IPerformanceStack stack, string? content)
         {
+            // If line is NULL or any time of whitespace, don't waste computation time searching any empty string
             if (string.IsNullOrWhiteSpace(content))
-            {
                 yield break;
-            }
+
             var matches = AddressExtractor.EmailRegex()
                 .Matches(content);
             using (var debug = stack.CreateStack("Run regex"))

--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -11,6 +11,8 @@ namespace MyAddressExtractor
         public bool OperateRecursively { get; private set; } = Defaults.OPERATE_RECURSIVELY;
         public bool SkipPrompts { get; private set; } = Defaults.SKIP_PROMPTS;
 
+        public bool Debug { get; private set; } = Defaults.DEBUG;
+
         public CommandLineProcessor(string[] args, IList<string> inputFilePaths)
         {
             if (args.Length == 0)
@@ -69,6 +71,9 @@ namespace MyAddressExtractor
                                     }
                                     Usage();
                                     return;
+                                case "-debug":
+                                    this.Debug = true;
+                                    break;
                                 default:
                                     throw new ArgumentException($"Unexpected option '{arg}'");
                             }
@@ -159,6 +164,8 @@ namespace MyAddressExtractor
             
             public const bool OPERATE_RECURSIVELY = false;
             public const bool SKIP_PROMPTS = false;
+
+            public const bool DEBUG = false;
         }
     }
 }

--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using System.Reflection;
+﻿using System.Reflection;
 using MyAddressExtractor.Objects;
 
 namespace MyAddressExtractor
@@ -56,14 +55,14 @@ namespace MyAddressExtractor
                                 case "y" or "-yes":
                                     this.SkipPrompts = true;
                                     break;
-                                case "v" or "--version":
+                                case "v" or "-version":
                                     if (args.Length > 1)
                                     {
                                         throw new ArgumentException($"'{arg}' must be the only argument when it is used");
                                     }
                                     Version();
                                     return;
-                                case "?" or "h" or "--help":
+                                case "?" or "h" or "-help":
                                     if (args.Length > 1)
                                     {
                                         throw new ArgumentException($"'{arg}' must be the only argument when it is used");

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace MyAddressExtractor {
     public static class Extensions {
         public static void AddAll<TKey, TVal>(this IDictionary<TKey, TVal> dictionary, IEnumerable<TKey> keys, TVal value)
@@ -6,6 +8,13 @@ namespace MyAddressExtractor {
             {
                 dictionary[key] = value;
             }
+        }
+
+        public static TimeSpan GetAndReset(this Stopwatch stopwatch)
+        {
+            var millis = stopwatch.Elapsed;
+            stopwatch.Restart();
+            return millis;
         }
     }
 }

--- a/src/Objects/Performance/DebugPerformanceStack.cs
+++ b/src/Objects/Performance/DebugPerformanceStack.cs
@@ -1,0 +1,178 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace MyAddressExtractor.Objects.Performance {
+    public sealed class DebugPerformanceStack : IPerformanceStack {
+        private readonly DebugPerformanceStack? Parent;
+        private readonly NodeAverage Node;
+        public string Name => this.Node.Name;
+
+        /// <summary>An ordered list of <see cref="Nodes"/>.Values and <see cref="Children"/>.Values</summary>
+        private readonly List<object> Entries = new();
+
+        /// <summary>A set of averages that are grouped within this <see cref="DebugPerformanceStack"/></summary>
+        private readonly ConcurrentDictionary<string, NodeAverage> Nodes = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Children <see cref="DebugPerformanceStack"/>s</summary>
+        private readonly ConcurrentDictionary<string, DebugPerformanceStack> Children = new(StringComparer.OrdinalIgnoreCase);
+
+        private readonly DateTimeOffset StartTime;
+        private readonly Stopwatch Stopwatch;
+
+        /// <summary>We evenly space log names so we need to know the longest length name</summary>
+        private int MaxLength;
+
+        public DebugPerformanceStack() : this(null, string.Empty) {}
+        private DebugPerformanceStack(DebugPerformanceStack? parent, string name)
+        {
+            this.Parent = parent;
+            this.Node = new NodeAverage(name);
+            this.StartTime = DateTimeOffset.UtcNow;
+            this.Stopwatch = Stopwatch.StartNew();
+            this.MaxLength = name.Length;
+        }
+
+        /// <inheritdoc />
+        public IPerformanceStack CreateStack(string name)
+            => new DebugPerformanceStack(this, name);
+
+        private void AddEntry(object entry)
+        {
+            this.Entries.Add(entry);
+            
+            string name;
+            if (entry is DebugPerformanceStack stack)
+                name = stack.Name;
+            else if (entry is NodeAverage average)
+                name = average.Name;
+            else return;
+            if (name.Length > this.MaxLength)
+                this.MaxLength = name.Length;
+        }
+
+        /// <inheritdoc />
+        public void Step(string name)
+        {
+            // Update the logging width
+            var len = name.Length;
+            if (len > this.MaxLength)
+                this.MaxLength = len;
+
+            var span = this.Stopwatch.GetAndReset();
+
+            var node = this.Nodes.GetOrAdd(name, i => {
+                var node = new NodeAverage(i);
+                this.AddEntry(node);
+                return node;
+            });
+
+            node.Add(span);
+        }
+
+        private void Write(DebugPerformanceStack child)
+        {
+            this.Children.AddOrUpdate(
+                // Add the entry using the name
+                child.Name,
+                // When first adding, also add to the Entries
+                _ => {
+                    this.AddEntry(child);
+                    return child;
+                },
+                // We can't have duplicate keys, so add the averages together
+                (s,  stack) => {
+                    stack.Node.Merge(child.Node);
+
+                    foreach (object entry in child.Entries) {
+                        if (entry is NodeAverage node)
+                        {
+                            stack.Nodes.AddOrUpdate(node.Name,
+                                _ => {
+                                    stack.AddEntry(node);
+                                    return node;
+                                },
+                                (_,  average) => {
+                                    average.Merge(node);
+                                    return average;
+                                }
+                            );
+                        }
+                        else if (entry is DebugPerformanceStack grandchild)
+                        {
+                            stack.Write(grandchild);
+                        }
+                    }
+                    
+                    return stack;
+                }
+            );
+        }
+
+        /// <inheritdoc />
+        public void Log()
+            => this.Log(0);
+        private void Log(int i)
+        {
+            int buffer = i * 2;
+            foreach (object entry in this.Entries)
+            {
+                if (entry is DebugPerformanceStack stack)
+                {
+                    if (!string.IsNullOrEmpty(stack.Name))
+                        stack.Node.Log(buffer, this.MaxLength);
+                    stack.Log(i + 1);
+                }
+                else if (entry is NodeAverage node)
+                {
+                    node.Log(buffer, this.MaxLength);
+                }
+            }
+
+            // If we're not recursing add a blank line at the end
+            if (this.Parent is null)
+                Console.WriteLine();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Node.Add(DateTimeOffset.UtcNow - this.StartTime);
+            this.Stopwatch.Stop();
+            this.Parent?.Write(this);
+        }
+
+        /// <summary>
+        /// This object is used for calculating the Millisecond Average that a <see cref="NodeAverage.Name"/>d action takes
+        /// </summary>
+        private sealed class NodeAverage {
+            public readonly string Name;
+
+            public TimeSpan Span { get; private set; }
+            public int Counter { get; private set; }
+
+            public NodeAverage(string name)
+            {
+                this.Name = name;
+            }
+
+            public void Add(TimeSpan span) {
+                this.Span += span;
+                this.Counter++;
+            }
+
+            public void Merge(NodeAverage other)
+            {
+                // Set the sum
+                this.Span += other.Span;
+
+                // Combine the counters
+                this.Counter += other.Counter;
+            }
+
+            public void Log(int left = 0, int right = 0)
+            {
+                Console.WriteLine($"{new string(' ', left)} - {this.Name.PadRight(right)} x{this.Counter:n0} | Took {this.Span.TotalMilliseconds:n0}ms (at ~{TimeUnitExtensions.Format(this.Span.TotalMicroseconds / this.Counter)} per)");
+            }
+        }
+    }
+}

--- a/src/Objects/Performance/IPerformanceStack.cs
+++ b/src/Objects/Performance/IPerformanceStack.cs
@@ -5,8 +5,14 @@ namespace MyAddressExtractor.Objects.Performance {
     public interface IPerformanceStack : IDisposable {
         static readonly IPerformanceStack DEFAULT = new DefaultPerformanceStack();
 
+        /// <summary>
+        /// Create a new nested stack
+        /// </summary>
         IPerformanceStack CreateStack(string name);
 
+        /// <summary>
+        /// Add a new measured step in the current stack
+        /// </summary>
         void Step(string name);
 
         void Log();

--- a/src/Objects/Performance/IPerformanceStack.cs
+++ b/src/Objects/Performance/IPerformanceStack.cs
@@ -1,0 +1,27 @@
+namespace MyAddressExtractor.Objects.Performance {
+    /// <summary>
+    /// A performance stack object for debugging performance
+    /// </summary>
+    public interface IPerformanceStack : IDisposable {
+        static readonly IPerformanceStack DEFAULT = new DefaultPerformanceStack();
+
+        IPerformanceStack CreateStack(string name);
+
+        void Step(string name);
+
+        void Log();
+
+        private sealed class DefaultPerformanceStack : IPerformanceStack {
+            /// <inheritdoc />
+            public IPerformanceStack CreateStack(string name)
+                => this;
+
+            /// <inheritdoc />
+            public void Step(string name) {}
+
+            public void Log() {}
+
+            void IDisposable.Dispose() {}
+        }
+    }
+}

--- a/src/Objects/TimeUnit.cs
+++ b/src/Objects/TimeUnit.cs
@@ -1,0 +1,49 @@
+namespace MyAddressExtractor.Objects {
+    public enum TimeUnit : long {
+        MICROSECONDS = 1,
+        MILLISECONDS = MICROSECONDS * 1000,
+        SECONDS = MILLISECONDS * 1000,
+        MINUTES = SECONDS * 60,
+        HOURS = MINUTES * 60,
+        DAYS = HOURS * 24
+    }
+    
+    public static class TimeUnitExtensions
+    {
+        public static double Convert(this TimeUnit to, double fromAmount, TimeUnit from = TimeUnit.MILLISECONDS)
+        {
+            double micro = fromAmount * (long)from;
+            return micro / (long)to;
+        }
+
+        public static string Format(this TimeUnit time) => time switch {
+            TimeUnit.MICROSECONDS => "μs",
+            TimeUnit.MILLISECONDS => "ms",
+            TimeUnit.SECONDS => "s",
+            TimeUnit.MINUTES => "m",
+            TimeUnit.HOURS => "h",
+            TimeUnit.DAYS => "d",
+            _ => throw new ArgumentOutOfRangeException(nameof(time), time, null)
+        };
+
+        public static string Format(double fromAmount, TimeUnit from = TimeUnit.MICROSECONDS)
+        {
+            var size = from;
+            var result = fromAmount;
+
+            foreach (TimeUnit unit in Enum.GetValues<TimeUnit>().OrderDescending()) {
+                if (unit <= from || fromAmount < (long)unit)
+                    continue;
+                var conversion = unit.Convert(fromAmount, from);
+
+                if (conversion > 0) {
+                    size = unit;
+                    result = conversion;
+                    break;
+                }
+            }
+
+            return $"{result:n0}{size.Format()}";
+        }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using MyAddressExtractor.Objects.Performance;
 
 [assembly:InternalsVisibleTo("AddressExtractorTest")]
 
@@ -46,7 +47,10 @@ namespace MyAddressExtractor
                     return (int)ErrorCode.NoError;
                 Console.WriteLine("Extracting...");
 
-                await using (var monitor = new AddressExtractorMonitor())
+                IPerformanceStack perf = config.Debug
+                    ? new DebugPerformanceStack() : IPerformanceStack.DEFAULT;
+
+                await using (var monitor = new AddressExtractorMonitor(perf))
                 {
                     await monitor.RunAsync(files, CancellationToken.None);
 


### PR DESCRIPTION
A start of a fix for #42. Seemed like a fun challenge to take a stab at

Added a `--debug` CLI flag to enable debug mode, it'll pass around an `IPerformanceStack` (which is meant to be similar to a `Stack` (eg; a Stacktrace)).

The interface mainly adds two methods

```csharp
// Create a new nested stack
IPerformanceStack CreateStack(string name);

// Add a new measured step in the current stack
void Step(string name);
```

When `--debug` is **not** enabled, it'll pass around an empty object which just calls void methods, so no accidental overhead performing normally:

```csharp
static readonly IPerformanceStack DEFAULT = new DefaultPerformanceStack();

private sealed class DefaultPerformanceStack : IPerformanceStack {
    /// <inheritdoc />
    public IPerformanceStack CreateStack(string name)
        => this;

    /// <inheritdoc />
    public void Step(string name) {}

    public void Log() {}

    void IDisposable.Dispose() {}
}
```

The new logger output with debug on is:
```
Extraction time: 2,052ms
Addresses extracted: 16
Read lines total: 285,130
Read lines rate: 138,952/s

 - Read file x6 | Took 2,049ms (at ~342ms per)
   - Read line x356,412 | Took 2,018ms (at ~6μs per)
   - Run regex x356,411 | Took 1,117ms (at ~3μs per)
     - Check length    x308,890 | Took 337ms (at ~1μs per)
     - Capture string  x308,890 | Took 73ms (at ~0μs per)
     - Filter invalids x308,890 | Took 127ms (at ~0μs per)
     - Validate domain x285,130 | Took 90ms (at ~0μs per)
```

`Read file` and `Run regex` have nested stacks under them (Just some nice formatting). This way the amount of time spent on each action can be seen, and the average time for each iteration (default: `microseconds`).

----

Also fixed an issue where `--help` was actually `---help` and `--version` was actually `---version`