### PR TITLE
A basic implementation of a .ODT reader

### DIFF
--- a/src/FileExtensionParsing.cs
+++ b/src/FileExtensionParsing.cs
@@ -72,6 +72,12 @@ namespace MyAddressExtractor {
                 new FileExtensionParsing { Error = "Not currently supported" }
             );
             
+            // Future - OpenDoc
+            extensions.AddAll(
+                new[] { ".odt" },
+                new FileExtensionParsing { Reader = path => new OpenDocumentTextReader(path) }
+            );
+            
             FileExtensionParsing.FILE_EXTENSIONS = extensions;
         }
         

--- a/src/Objects/Readers/OpenDocumentTextReader.cs
+++ b/src/Objects/Readers/OpenDocumentTextReader.cs
@@ -1,0 +1,61 @@
+
+using System.IO.Compression;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace MyAddressExtractor.Objects.Readers {
+    internal sealed class OpenDocumentTextReader : ILineReader
+    {
+        private readonly FileStream? FileStream;
+        private readonly StreamReader? StreamReader;
+        private bool initialised = false;
+        
+
+        public OpenDocumentTextReader(string zipPath)
+        {
+            using (ZipArchive archive = ZipFile.OpenRead(zipPath))
+            {
+                foreach (ZipArchiveEntry entry in archive.Entries)
+                {
+                    if (entry.FullName.Equals("content.xml", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var extractPath = Path.GetTempPath();
+                        
+                        string destinationPath = Path.GetFullPath(Path.Combine(extractPath, entry.FullName));
+
+                        if (destinationPath.StartsWith(extractPath, StringComparison.Ordinal))
+                        {
+                            entry.ExtractToFile(destinationPath);
+
+                            this.FileStream = new FileStream(destinationPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, FileOptions.SequentialScan | FileOptions.Asynchronous);
+                            this.StreamReader = new StreamReader(this.FileStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096);
+                            this.initialised = true;
+                        }
+                    }
+                }
+            }
+
+            if(!this.initialised)
+            {
+                throw new Exception($"Unable to load content.xml from '{zipPath}'");
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if(this.initialised)
+            {
+                this.StreamReader?.Dispose();
+                await this.FileStream!.DisposeAsync();
+            }
+        }
+
+        public async IAsyncEnumerable<string?> ReadLineAsync([EnumeratorCancellation] CancellationToken cancellation = default)
+        {
+            while (!this.StreamReader!.EndOfStream)
+            {
+                yield return await this.StreamReader!.ReadLineAsync(cancellation);
+            }
+        }
+    }
+}

--- a/src/Objects/Readers/OpenDocumentTextReader.cs
+++ b/src/Objects/Readers/OpenDocumentTextReader.cs
@@ -1,4 +1,6 @@
 using System.IO.Compression;
+using System.Text;
+using System.Xml;
 
 namespace MyAddressExtractor.Objects.Readers {
     internal sealed class OpenDocumentTextReader : PlainTextReader
@@ -19,7 +21,21 @@ namespace MyAddressExtractor.Objects.Readers {
                 {
                     if (entry.FullName.Equals("content.xml", StringComparison.OrdinalIgnoreCase))
                     {
-                        entry.ExtractToFile(DestinationPath, true);
+                        using(var writer = new StreamWriter(DestinationPath, true, Encoding.UTF8, 4096))
+                        {
+                            using(var reader = new XmlTextReader(entry.Open()))
+                            {
+                                while(reader.Read())
+                                {
+                                    if (reader.NodeType == XmlNodeType.Text ||
+                                        reader.NodeType == XmlNodeType.CDATA)
+                                    {
+                                        writer.WriteLine(reader.ReadContentAsString());
+                                    }
+                                }
+                            }
+                        }
+
                         return DestinationPath;
                     }
                 }

--- a/src/Objects/Readers/PlainTextReader.cs
+++ b/src/Objects/Readers/PlainTextReader.cs
@@ -2,7 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace MyAddressExtractor.Objects.Readers {
-    internal sealed class PlainTextReader : ILineReader
+    internal class PlainTextReader : ILineReader
     {
         private readonly FileStream FileStream;
         private readonly StreamReader StreamReader;
@@ -23,7 +23,7 @@ namespace MyAddressExtractor.Objects.Readers {
         }
 
         /// <inheritdoc />
-        public async ValueTask DisposeAsync()
+        public async virtual ValueTask DisposeAsync()
         {
             this.StreamReader.Dispose();
             await this.FileStream.DisposeAsync();

--- a/src/Objects/Readers/PlainTextReader.cs
+++ b/src/Objects/Readers/PlainTextReader.cs
@@ -27,6 +27,7 @@ namespace MyAddressExtractor.Objects.Readers {
         {
             this.StreamReader.Dispose();
             await this.FileStream.DisposeAsync();
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
The OpenDocumentTextReader will extract content.xml from the .ODT, parse the file and then write the text into a temporary file which is the passed into PlainTextReader for further parsing for email addresses.