### PR TITLE
Added some tests / other cleanup

### DIFF
--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -13,9 +13,9 @@ namespace MyAddressExtractor
 
         public bool Debug { get; private set; } = Defaults.DEBUG;
 
-        public CommandLineProcessor(string[] args, IList<string> inputFilePaths)
+        public CommandLineProcessor(IReadOnlyCollection<string> args, out IList<string> inputFilePaths)
         {
-            if (args.Length == 0)
+            if (args.Count == 0)
             {
                 throw new ArgumentException("Please provide at least one input file path.");
             }
@@ -23,6 +23,7 @@ namespace MyAddressExtractor
             Action<string>? handle = null;
             string previous = string.Empty;
 
+            inputFilePaths = new List<string>();
             foreach (var arg in args)
             {
                 if (handle is not null)
@@ -58,14 +59,14 @@ namespace MyAddressExtractor
                                     this.SkipPrompts = true;
                                     break;
                                 case "v" or "-version":
-                                    if (args.Length > 1)
+                                    if (args.Count > 1)
                                     {
                                         throw new ArgumentException($"'{arg}' must be the only argument when it is used");
                                     }
                                     Version();
                                     return;
                                 case "?" or "h" or "-help":
-                                    if (args.Length > 1)
+                                    if (args.Count > 1)
                                     {
                                         throw new ArgumentException($"'{arg}' must be the only argument when it is used");
                                     }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -21,12 +21,12 @@ namespace MyAddressExtractor
 
         static async Task<int> Main(string[] args)
         {
-            var inputFilePaths = new List<string>();
+            IList<string> inputFilePaths;
 
             CommandLineProcessor config;
             try
             {
-                config = new CommandLineProcessor(args, inputFilePaths);
+                config = new CommandLineProcessor(args, out inputFilePaths);
             }
             catch (ArgumentException ae)
             {

--- a/test/CommandLineProcessorTests.cs
+++ b/test/CommandLineProcessorTests.cs
@@ -6,15 +6,16 @@ namespace AddressExtractorTest
     [TestClass]
     public class CommandLineProcessorTests
     {
+        #region Invalid Input
+
         [TestMethod]
         public void NoArguments()
         {
             // Arrange
             var args = Array.Empty<string>();
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
 
         [TestMethod]
@@ -22,10 +23,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "-o", "output" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
 
         [TestMethod]
@@ -33,10 +33,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-o" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
 
         [TestMethod]
@@ -44,10 +43,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-r" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
 
         [TestMethod]
@@ -55,10 +53,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-o", "-r", "report" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
 
         [TestMethod]
@@ -66,10 +63,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-r", "-o", "output" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
 
         [TestMethod]
@@ -77,10 +73,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
 
         [TestMethod]
@@ -88,21 +83,21 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-z" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
+
+        #endregion
 
         [TestMethod]
         public void Usage()
         {
             // Arrange
             var args = new[] { "-?" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            var config = new CommandLineProcessor(args, inputs);
+            var config = new CommandLineProcessor(args, out _);
             // Successful if no exception thrown
         }
 
@@ -111,10 +106,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input", "-?" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
 
         [TestMethod]
@@ -122,22 +116,25 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "-?", "input" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
+
+        #region Version flag
 
         [TestMethod]
         public void Version()
         {
-            // Arrange
-            var args = new[] { "-v" };
-            var inputs = new List<string>();
+            var all = new[] { "-v", "--version" };
+            foreach (var option in all) {
+                // Arrange
+                var args = new[] { option };
 
-            // Act and Assert
-            var config = new CommandLineProcessor(args, inputs);
-            // Successful if no exception thrown
+                // Act and Assert
+                var config = new CommandLineProcessor(args, out _);
+                // Successful if no exception thrown
+            }
         }
 
         [TestMethod]
@@ -145,10 +142,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input", "-v" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
 
         [TestMethod]
@@ -156,21 +152,49 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "-v", "input" };
-            var inputs = new List<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, inputs));
+            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
         }
+
+        #endregion
+        #region Config flags
+
+        [TestMethod]
+        public void Debug()
+        {
+            var args = new[] { "input", "--debug" };
+
+            // Act and Assert
+            var config = new CommandLineProcessor(args, out _);
+            Assert.IsTrue(config.Debug, "Debug mode should be enabled");
+        }
+
+        [TestMethod]
+        public void SkipPrompt()
+        {
+            var all = new[] { "-y", "--yes" };
+            foreach (var option in all) {
+                // Arrange
+                var args = new[] { "input", option };
+
+                // Act and Assert
+                var config = new CommandLineProcessor(args, out _);
+                Assert.IsTrue(config.SkipPrompts, "Skipping prompts should be enabled");
+            }
+        }
+
+        #endregion
+        #region File Inputs
 
         [TestMethod]
         public void OneInput()
         {
             // Arrange
             var args = new[] { "input1" };
-            var inputs = new List<string>();
 
             // Act
-            var config = new CommandLineProcessor(args, inputs);
+            var config = new CommandLineProcessor(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
@@ -184,10 +208,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "input2" };
-            var inputs = new List<string>();
 
             // Act
-            var config = new CommandLineProcessor(args, inputs);
+            var config = new CommandLineProcessor(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 2);
@@ -197,15 +220,16 @@ namespace AddressExtractorTest
             Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
         }
 
+        #endregion
+
         [TestMethod]
         public void Output()
         {
             // Arrange
             var args = new[] { "input1", "-o", "output" };
-            var inputs = new List<string>();
 
             // Act
-            var config = new CommandLineProcessor(args, inputs);
+            var config = new CommandLineProcessor(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
@@ -219,10 +243,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-r", "report" };
-            var inputs = new List<string>();
 
             // Act
-            var config = new CommandLineProcessor(args, inputs);
+            var config = new CommandLineProcessor(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
@@ -236,10 +259,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-o", "output", "-r", "report" };
-            var inputs = new List<string>();
 
             // Act
-            var config = new CommandLineProcessor(args, inputs);
+            var config = new CommandLineProcessor(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
@@ -253,10 +275,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-r", "report", "-o", "output" };
-            var inputs = new List<string>();
 
             // Act
-            var config = new CommandLineProcessor(args, inputs);
+            var config = new CommandLineProcessor(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
@@ -270,10 +291,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "input2", "-o", "output" };
-            var inputs = new List<string>();
 
             // Act
-            var config = new CommandLineProcessor(args, inputs);
+            var config = new CommandLineProcessor(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 2);
@@ -288,10 +308,9 @@ namespace AddressExtractorTest
         {
             // Arrange
             var args = new[] { "input1", "-o", "output", "input2" };
-            var inputs = new List<string>();
 
             // Act
-            var config = new CommandLineProcessor(args, inputs);
+            var config = new CommandLineProcessor(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 2);

--- a/test/CommandLineProcessorTests.cs
+++ b/test/CommandLineProcessorTests.cs
@@ -93,12 +93,16 @@ namespace AddressExtractorTest
         [TestMethod]
         public void Usage()
         {
-            // Arrange
-            var args = new[] { "-?" };
+            var all = new[] { "-?", "-h", "--help" };
+            foreach (var option in all)
+            {
+                // Arrange
+                var args = new[] { option };
 
-            // Act and Assert
-            var config = new CommandLineProcessor(args, out _);
-            // Successful if no exception thrown
+                // Act and Assert
+                var config = new CommandLineProcessor(args, out _);
+                // Successful if no exception thrown
+            }
         }
 
         [TestMethod]
@@ -127,7 +131,8 @@ namespace AddressExtractorTest
         public void Version()
         {
             var all = new[] { "-v", "--version" };
-            foreach (var option in all) {
+            foreach (var option in all)
+            {
                 // Arrange
                 var args = new[] { option };
 
@@ -174,7 +179,8 @@ namespace AddressExtractorTest
         public void SkipPrompt()
         {
             var all = new[] { "-y", "--yes" };
-            foreach (var option in all) {
+            foreach (var option in all)
+            {
                 // Arrange
                 var args = new[] { "input", option };
 


### PR DESCRIPTION
Added some tests for the new CLI inputs: `--debug`, and `--yes`. Also expanded tests for (`-?` to include `-h` and `--help`, and `-v` to include `--version`

----

Changed the 2nd parameter from `CommandLineProcessor` to be an `out` variable. Since it's always functionally been a list reference, and there is no situation where we pass in pre-existing values.

Being an `out` now we can simplifyy Tests by simply discarding the `out _` instead of creating a `new List<string>()` for every usage.