### PR TITLE
AddressExtractor refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+# IDEA IDEs
+.idea/
+
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -31,7 +31,7 @@ namespace MyAddressExtractor
             await foreach (var line in reader.ReadLineAsync(cancellation))
             {
                 stack.Step("Read line");
-                await foreach (var address in this.ExtractAddressesAsync(stack, line))
+                await foreach (var address in this.ExtractAddressesAsync(stack, line, cancellation))
                 {
                     yield return address;
                 }

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -11,7 +11,14 @@ namespace MyAddressExtractor
         /// <summary>
         /// Email Regex pattern
         /// </summary>
-        [GeneratedRegex(@"(\\"")?""?'?[a-z0-9\.\-\*!#$%&'+/=?^_`{|}~""\\]+(?<!\.)@([a-z0-9\-_]+\.)+[a-z0-9]{2,}\b(\\"")?""?'?(?<!\s)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled)]
+        [GeneratedRegex(
+            @"(\\"")?""?'?[a-z0-9\.\-\*!#$%&'+/=?^_`{|}~""\\]+(?<!\.)@([a-z0-9\-_]+\.)+[a-z0-9]{2,}\b(\\"")?""?'?(?<!\s)",
+            RegexOptions.ExplicitCapture // Require naming captures; implies '(?:)' on groups. We don't make use of the groups
+            | RegexOptions.IgnoreCase // Match upper and lower casing
+            | RegexOptions.Compiled // Compile the nodes
+            | RegexOptions.Singleline // Singleline mode
+            | RegexOptions.CultureInvariant // Allow culture invariant character matching
+        )]
         public static partial Regex EmailRegex();
 
         /// <summary>
@@ -23,7 +30,13 @@ namespace MyAddressExtractor
         /// .@	    Email having .@
         /// @-	    Email having @-
         /// </remarks>
-        [GeneratedRegex(@"\.\.|\*|\.@|^\.|@-", RegexOptions.Compiled)]
+        [GeneratedRegex(
+            @"\.\.|\*|\.@|^\.|@-",
+            RegexOptions.ExplicitCapture // Require naming captures; implies '(?:)' on groups. We don't make use of the groups
+            | RegexOptions.IgnoreCase // Match upper and lower casing
+            | RegexOptions.Compiled // Compile the nodes
+            | RegexOptions.Singleline // Singleline mode
+        )]
         public static partial Regex InvalidEmailRegex();
 
         public IAsyncEnumerable<string> ExtractAddressesAsync(ILineReader reader, CancellationToken cancellation = default)

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -1,6 +1,6 @@
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.RegularExpressions;
+using MyAddressExtractor.Objects;
 using MyAddressExtractor.Objects.Performance;
 using MyAddressExtractor.Objects.Readers;
 
@@ -21,43 +21,30 @@ namespace MyAddressExtractor
         )]
         public static partial Regex EmailRegex();
 
-        /// <summary>
-        /// A negative-regex pattern for filtering out bad emails
-        /// </summary>
-        /// <remarks>
-        /// \.\.	Email having consecutive dot
-        /// \*	    Email having *
-        /// .@	    Email having .@
-        /// @-	    Email having @-
-        /// </remarks>
-        [GeneratedRegex(
-            @"\.\.|\*|\.@|^\.|@-",
-            RegexOptions.ExplicitCapture // Require naming captures; implies '(?:)' on groups. We don't make use of the groups
-            | RegexOptions.IgnoreCase // Match upper and lower casing
-            | RegexOptions.Compiled // Compile the nodes
-            | RegexOptions.Singleline // Singleline mode
-        )]
-        public static partial Regex InvalidEmailRegex();
+        #region File Extraction
 
-        public IAsyncEnumerable<string> ExtractAddressesAsync(ILineReader reader, CancellationToken cancellation = default)
-            => this.ExtractAddressesAsync(IPerformanceStack.DEFAULT, reader, cancellation);
+        public IAsyncEnumerable<string> ExtractFileAddressesAsync(ILineReader reader, CancellationToken cancellation = default)
+            => this.ExtractFileAddressesAsync(IPerformanceStack.DEFAULT, reader, cancellation);
 
-        public async IAsyncEnumerable<string> ExtractAddressesAsync(IPerformanceStack stack, ILineReader reader, [EnumeratorCancellation] CancellationToken cancellation = default)
+        public async IAsyncEnumerable<string> ExtractFileAddressesAsync(IPerformanceStack stack, ILineReader reader, [EnumeratorCancellation] CancellationToken cancellation = default)
         {
             await foreach (var line in reader.ReadLineAsync(cancellation))
             {
                 stack.Step("Read line");
-                foreach (var address in this.ExtractAddresses(stack, line))
+                await foreach (var address in this.ExtractAddressesAsync(stack, line))
                 {
                     yield return address;
                 }
             }
         }
 
-        public IEnumerable<string> ExtractAddresses(string? content)
-            => this.ExtractAddresses(IPerformanceStack.DEFAULT, content);
+        #endregion
+        #region String Extraction
 
-        private IEnumerable<string> ExtractAddresses(IPerformanceStack stack, string? content)
+        public IAsyncEnumerable<string> ExtractAddressesAsync(string? content, CancellationToken cancellation = default)
+            => this.ExtractAddressesAsync(IPerformanceStack.DEFAULT, content, cancellation);
+
+        private async IAsyncEnumerable<string> ExtractAddressesAsync(IPerformanceStack stack, string? content, [EnumeratorCancellation] CancellationToken cancellation = default)
         {
             // If line is NULL or any time of whitespace, don't waste computation time searching any empty string
             if (string.IsNullOrWhiteSpace(content))
@@ -65,95 +52,33 @@ namespace MyAddressExtractor
 
             var matches = AddressExtractor.EmailRegex()
                 .Matches(content);
+
             using (var debug = stack.CreateStack("Run regex"))
             {
                 foreach (Match match in matches) {
-                    // Use the match position to validate too long of a length so we don't have to allocate the string
-                    if (match.Index + match.Length >= 256)
-                        continue;
-                    debug.Step("Check length");
+                    var address = new EmailAddress(match);
+                    debug.Step("Generate capture");
 
-                    string email = match.Value;
-                    debug.Step("Capture string");
+                    var valid = true;
+                    foreach (var filter in AddressFilter.Filters) {
+                        var result = await filter.ValidateEmailAddressAsync(address, cancellation);
+                        debug.Step(filter.Name);
 
-                    // Handle quotes at the start and end of the match
-                    if (email.StartsWith('\'') && email.EndsWith('\''))
-                        email = email[1..^1];
-                    if (email.StartsWith('"') && email.EndsWith('"'))
-                        email = email[1..^1];
-                    if (email.StartsWith("\\\"") && email.EndsWith("\\\""))
-                        email = email[2..^2];
-
-                    // Filter out edge case addresses
-                    if (AddressExtractor.InvalidEmailRegex().IsMatch(email))
-                        continue;
-                    debug.Step("Filter invalids");
-
-                    // Is there a single backslash enclosed in quotes? if yes, that's ok. A single backslash without quotes is not
-                    var username = email[0..email.LastIndexOf('@')];
-                    // Handle quotes at the start and end of the username
-                    if (username.StartsWith('\'') && username.EndsWith('\''))
-                        username = username[1..^1];
-                    if (username.StartsWith('"') && username.EndsWith('"'))
-                        username = username[1..^1];
-                    if (username.StartsWith("\\\"") && username.EndsWith("\\\""))
-                        username = username[2..^2];
-
-                    // Does the username contain any unescaped double quotes?
-                    var quoteIndex = username.IndexOf('"');
-                    int unescapedQuoteCount = 0;
-                    bool passed = true;
-                    while (passed && quoteIndex != -1)
-                    {
-                        if (quoteIndex == 0 || (quoteIndex > 0 && username[quoteIndex - 1] != '\\'))
+                        if (result is not Result.CONTINUE)
                         {
-                            unescapedQuoteCount++;
+                            valid = result is Result.ALLOW;
+                            break;
                         }
-                        quoteIndex = username.IndexOf('"', quoteIndex + 1);
                     }
 
-                    // Does it contain mismatched (an odd number) quotes?
-                    if ((unescapedQuoteCount & 1) == 1)
+                    if (!valid)
                         continue;
 
-                    var domain = email[email.LastIndexOf('@')..];
-                    // Handle cases such as: foo@bar.1com, foo@bar.12com
-                    if (char.IsNumber(domain[domain.LastIndexOf('.')+1]))
-                        continue;
-                    // Handle cases such as: foobar@_.com
-                    if (domain[1..domain.LastIndexOf('.')] == "_")
-                        continue;
-                    // Handle cases such as: username@-example-.com and username@example-.com
-                    if (domain.Contains("-."))
-                        continue;
-
-                    debug.Step("Validate domain");
-
-                    yield return email;
+                    yield return address.Full;
                 }
             }
         }
 
-        public async ValueTask SaveAddressesAsync(string filePath, IEnumerable<string> addresses, CancellationToken cancellation = default)
-        {
-            await File.WriteAllLinesAsync(
-                filePath,
-                addresses.Select(address => address.ToLowerInvariant())
-                    .OrderBy(address => address, StringComparer.OrdinalIgnoreCase),
-                cancellation
-            );
-        }
-
-        public async ValueTask SaveReportAsync(string filePath, IDictionary<string, Count> uniqueAddressesPerFile, CancellationToken cancellation = default)
-        {
-            var reportContent = new StringBuilder("Unique addresses per file:\n");
-            
-            foreach ((var file, var count) in uniqueAddressesPerFile)
-            {
-                reportContent.AppendLine($"{file}: {count}");
-            }
-            
-            await File.WriteAllTextAsync(filePath, reportContent.ToString(), cancellation);
-        }
+        #endregion
     }
 }

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
+using MyAddressExtractor.Objects;
 using MyAddressExtractor.Objects.Performance;
 
 namespace MyAddressExtractor {
@@ -49,7 +50,7 @@ namespace MyAddressExtractor {
 
         public virtual void Log()
         {
-            Console.WriteLine($"Extraction time: {this.Stopwatch.ElapsedMilliseconds:n0}ms");
+            Console.WriteLine($"Extraction time: {TimeUnitExtensions.Format(this.Stopwatch.ElapsedMilliseconds, TimeUnit.MILLISECONDS)}");
             Console.WriteLine($"Addresses extracted: {this.Addresses.Count:n0}");
             long rate = (long)(this.Lines / (this.Stopwatch.ElapsedMilliseconds / 1000.0));
             Console.WriteLine($"Read lines total: {this.Lines:n0}");

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
-using MyAddressExtractor.Objects;
 using MyAddressExtractor.Objects.Performance;
 
 namespace MyAddressExtractor {
@@ -50,7 +49,7 @@ namespace MyAddressExtractor {
 
         public virtual void Log()
         {
-            Console.WriteLine($"Extraction time: {TimeUnitExtensions.Format(this.Stopwatch.ElapsedMilliseconds, TimeUnit.MILLISECONDS)}");
+            Console.WriteLine($"Extraction time: {this.Stopwatch.Format()}");
             Console.WriteLine($"Addresses extracted: {this.Addresses.Count:n0}");
             long rate = (long)(this.Lines / (this.Stopwatch.ElapsedMilliseconds / 1000.0));
             Console.WriteLine($"Read lines total: {this.Lines:n0}");

--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -113,12 +113,15 @@ namespace MyAddressExtractor
 
             while (true)
             {
-                Console.WriteLine("Press ANY KEY to continue ['Q' to Quit; 'I' for info].");
+                Console.Write("Press ANY KEY to continue ['Q' to Quit; 'I' for info]: ");
                 var read = Console.ReadKey(intercept: true);
+                Console.WriteLine();
 
                 // No modifiers (shift/ctrl/alt)
-                if (read.Modifiers is 0) {
-                    switch (read.Key) {
+                if (read.Modifiers is 0)
+                {
+                    switch (read.Key)
+                    {
                         case ConsoleKey.Q:
                             Console.WriteLine("Exiting");
                             return false;
@@ -133,6 +136,37 @@ namespace MyAddressExtractor
                             continue;
                         default:
                             return true;
+                    }
+                }
+            }
+        }
+
+        internal bool WaitContinue()
+        {
+            // If silent output don't prompt
+            if (this.SkipPrompts)
+                return true;
+
+            Console.Write("Continue? [y/n]: ");
+            while (true)
+            {
+                var read = Console.ReadKey(intercept: true);
+
+                // No modifiers (shift/ctrl/alt)
+                if (read.Modifiers is 0)
+                {
+                    switch (read.Key)
+                    {
+                        // Allow continuing
+                        case ConsoleKey.Y:
+                            Console.WriteLine();
+                            return true;
+
+                        // Exit
+                        case ConsoleKey.N:
+                        case ConsoleKey.Escape:
+                            Console.WriteLine();
+                            return false;
                     }
                 }
             }

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using MyAddressExtractor.Objects;
 
 namespace MyAddressExtractor {
     public static class Extensions {
@@ -16,5 +17,22 @@ namespace MyAddressExtractor {
             stopwatch.Restart();
             return millis;
         }
+
+        public static string Format(this Stopwatch stopwatch, TimeUnit precision = TimeUnit.MICROSECONDS)
+            => stopwatch.Elapsed.Format(precision);
+
+        public static string Format(this TimeSpan span, TimeUnit precision = TimeUnit.MICROSECONDS)
+            => TimeUnitExtensions.Format(span.Total(precision), precision);
+
+        public static double Total(this TimeSpan span, TimeUnit unit) => unit switch
+        {
+            TimeUnit.MICROSECONDS => span.TotalMicroseconds,
+            TimeUnit.MILLISECONDS => span.TotalMilliseconds,
+            TimeUnit.SECONDS => span.TotalSeconds,
+            TimeUnit.MINUTES => span.TotalMinutes,
+            TimeUnit.HOURS => span.TotalHours,
+            TimeUnit.DAYS => span.TotalDays,
+            _ => throw new ArgumentOutOfRangeException(nameof(unit), unit, null)
+        };
     }
 }

--- a/src/Objects/AddressFilter.cs
+++ b/src/Objects/AddressFilter.cs
@@ -30,11 +30,11 @@ namespace MyAddressExtractor.Objects {
             /// <summary>A Name for the Filter, which is added to the Debug Stack when run</summary>
             public abstract string Name { get; }
 
-            public virtual Result ValidateEmailAddress(EmailAddress address)
+            public virtual Result ValidateEmailAddress(ref EmailAddress address)
                 => Result.CONTINUE;
 
-            public virtual ValueTask<Result> ValidateEmailAddressAsync(EmailAddress address, CancellationToken cancellation = default)
-                => ValueTask.FromResult(this.ValidateEmailAddress(address));
+            public virtual ValueTask<Result> ValidateEmailAddressAsync(ref EmailAddress address, CancellationToken cancellation = default)
+                => ValueTask.FromResult(this.ValidateEmailAddress(ref address));
 
             /// <summary>Convert a <see cref="bool"/> to a <see cref="Result"/>, CONTINUE when true, or DENY when false</summary>
             protected Result Continue(bool success)

--- a/src/Objects/AddressFilter.cs
+++ b/src/Objects/AddressFilter.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Reflection;
+using MyAddressExtractor.Objects.Attributes;
+
+namespace MyAddressExtractor.Objects {
+    public sealed class AddressFilter {
+        public static readonly IEnumerable<BaseFilter> Filters;
+        static AddressFilter()
+        {
+            var filters = new FilterCollection();
+            var types = Assembly.GetExecutingAssembly()
+                .GetTypes()
+                .Where(type => type.IsClass && !type.IsAbstract && type.IsAssignableTo(typeof(BaseFilter)))
+                .OrderByDescending(type => type.GetCustomAttribute<AddressFilterAttribute>()?.Priority ?? -1);
+            foreach (Type type in types)
+            {
+                if (Activator.CreateInstance(type) is BaseFilter filter)
+                    filters.Add(filter);
+            }
+
+            AddressFilter.Filters = filters;
+        }
+
+        /// <summary>
+        /// A base class for checking whether an Email Address should be filtered out
+        /// Instances of <see cref="BaseFilter"/> are created automatically using Reflection when the program starts
+        /// A priority for the Filter can be applied using a <see cref="AddressFilterAttribute"/>
+        /// </summary>
+        public abstract class BaseFilter {
+            /// <summary>A Name for the Filter, which is added to the Debug Stack when run</summary>
+            public abstract string Name { get; }
+
+            public virtual Result ValidateEmailAddress(EmailAddress address)
+                => Result.CONTINUE;
+
+            public virtual ValueTask<Result> ValidateEmailAddressAsync(EmailAddress address, CancellationToken cancellation = default)
+                => ValueTask.FromResult(this.ValidateEmailAddress(address));
+
+            /// <summary>Convert a <see cref="bool"/> to a <see cref="Result"/>, CONTINUE when true, or DENY when false</summary>
+            protected Result Continue(bool success)
+                => success ? Result.CONTINUE : Result.DENY;
+        }
+
+        private sealed class FilterCollection : IEnumerable<BaseFilter> {
+            /// <summary>Use a List so that we maintain entry order</summary>
+            private readonly IList<BaseFilter> Filters = new List<BaseFilter>();
+
+            public void Add(BaseFilter filter)
+                => this.Filters.Add(filter);
+
+            /// <inheritdoc />
+            public IEnumerator<BaseFilter> GetEnumerator()
+                => this.Filters.GetEnumerator();
+
+            /// <inheritdoc />
+            IEnumerator IEnumerable.GetEnumerator()
+                => this.GetEnumerator();
+        }
+    }
+}

--- a/src/Objects/Attributes/AddressFilterAttribute.cs
+++ b/src/Objects/Attributes/AddressFilterAttribute.cs
@@ -1,0 +1,6 @@
+namespace MyAddressExtractor.Objects.Attributes {
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class AddressFilterAttribute : Attribute {
+        public int Priority { get; set; } = 0;
+    }
+}

--- a/src/Objects/EmailAddress.cs
+++ b/src/Objects/EmailAddress.cs
@@ -22,6 +22,8 @@ namespace MyAddressExtractor.Objects {
                 this._Separator = null;
                 this._Username = null;
                 this._Domain = null;
+
+                this.Modified = true;
             }
         }
         private string? _Full = null;
@@ -42,6 +44,9 @@ namespace MyAddressExtractor.Objects {
 
         /// <summary>The Length of the Full Address</summary>
         public int Length => this._Full?.Length ?? this.Match.Length;
+
+        /// <summary>If the <see cref="Full"/> was manually overridden</summary>
+        public bool Modified { get; private set; } = false;
 
         public EmailAddress(Match match)
         {

--- a/src/Objects/EmailAddress.cs
+++ b/src/Objects/EmailAddress.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+
+namespace MyAddressExtractor.Objects {
+    public struct EmailAddress {
+        private readonly Match Match;
+
+        public string Full => this._Full ??= this.Match.Value;
+        private string? _Full = null;
+
+        public string Username => this._Username ??= this.Full[..this.Separator];
+        private string? _Username = null;
+
+        public string Domain => this._Domain ??= this.Full[this.Separator..];
+        private string? _Domain = null;
+
+        /// <summary>Cache where the '@' separate is for 'Username' and 'Domain' so we don't keep calling 'IndexOf()'</summary>
+        private int Separator => this._Separator ??= this.Full.LastIndexOf('@');
+        private int? _Separator = null;
+
+        public int Length => this.Match.Length - this.Match.Index;
+
+        public EmailAddress(Match match)
+        {
+            this.Match = match;
+        }
+    }
+}

--- a/src/Objects/EmailAddress.cs
+++ b/src/Objects/EmailAddress.cs
@@ -41,7 +41,7 @@ namespace MyAddressExtractor.Objects {
         private int? _Separator = null;
 
         /// <summary>The Length of the Full Address</summary>
-        public int Length => this.Full.Length;
+        public int Length => this._Full?.Length ?? this.Match.Length;
 
         public EmailAddress(Match match)
         {

--- a/src/Objects/EmailAddress.cs
+++ b/src/Objects/EmailAddress.cs
@@ -4,12 +4,34 @@ namespace MyAddressExtractor.Objects {
     public struct EmailAddress {
         private readonly Match Match;
 
-        public string Full => this._Full ??= this.Match.Value;
+        /// <summary>
+        /// <para>The full email address.</para>
+        /// 
+        /// This value can be set by <see cref="AddressFilter.BaseFilter"/>s, to trim or otherwise make tweaks to the address.
+        /// <b>Be careful changing this</b>, filters are not rerun. The new value may not have passed previous filters.
+        /// </summary>
+        /// <example>username@test.com</example>
+        public string Full {
+            get => this._Full ??= this.Match.Value;
+            set {
+                // Update the full address to something else
+                this._Full = value ?? throw new NullReferenceException();
+
+                // Clear the cache
+                this._Separator = null;
+                this._Username = null;
+                this._Domain = null;
+            }
+        }
         private string? _Full = null;
 
+        /// <summary>The username part of the address.</summary>
+        /// <example>username</example>
         public string Username => this._Username ??= this.Full[..this.Separator];
         private string? _Username = null;
 
+        /// <summary>The domain part of the address.</summary>
+        /// <example>test.com</example>
         public string Domain => this._Domain ??= this.Full[this.Separator..];
         private string? _Domain = null;
 
@@ -17,7 +39,8 @@ namespace MyAddressExtractor.Objects {
         private int Separator => this._Separator ??= this.Full.LastIndexOf('@');
         private int? _Separator = null;
 
-        public int Length => this.Match.Length - this.Match.Index;
+        /// <summary>The Length of the Full Address</summary>
+        public int Length => this._Full?.Length ?? this.Match.Length - this.Match.Index;
 
         public EmailAddress(Match match)
         {

--- a/src/Objects/EmailAddress.cs
+++ b/src/Objects/EmailAddress.cs
@@ -41,7 +41,7 @@ namespace MyAddressExtractor.Objects {
         private int? _Separator = null;
 
         /// <summary>The Length of the Full Address</summary>
-        public int Length => this._Full?.Length ?? this.Match.Length - this.Match.Index;
+        public int Length => this.Full.Length;
 
         public EmailAddress(Match match)
         {

--- a/src/Objects/EmailAddress.cs
+++ b/src/Objects/EmailAddress.cs
@@ -1,7 +1,8 @@
 using System.Text.RegularExpressions;
 
 namespace MyAddressExtractor.Objects {
-    public struct EmailAddress {
+    public struct EmailAddress
+    {
         private readonly Match Match;
 
         /// <summary>

--- a/src/Objects/Filters/DomainFilter.cs
+++ b/src/Objects/Filters/DomainFilter.cs
@@ -1,0 +1,28 @@
+using MyAddressExtractor.Objects.Attributes;
+
+namespace MyAddressExtractor.Objects.Filters {
+    [AddressFilter(Priority = 900)]
+    public sealed class DomainFilter : AddressFilter.BaseFilter {
+        public override string Name => "Domain filter";
+
+        /// <inheritdoc />
+        public override Result ValidateEmailAddress(EmailAddress address)
+        {
+            var domain = address.Domain;
+
+            // Handle cases such as: foo@bar.1com, foo@bar.12com
+            if (char.IsNumber(domain[domain.LastIndexOf('.')+1]))
+                return Result.DENY;
+
+            // Handle cases such as: foobar@_.com
+            if (domain[1..domain.LastIndexOf('.')] == "_")
+                return Result.DENY;
+
+            // Handle cases such as: username@-example-.com and username@example-.com
+            if (domain.Contains("-."))
+                return Result.DENY;
+
+            return Result.CONTINUE;
+        }
+    }
+}

--- a/src/Objects/Filters/DomainFilter.cs
+++ b/src/Objects/Filters/DomainFilter.cs
@@ -6,7 +6,7 @@ namespace MyAddressExtractor.Objects.Filters {
         public override string Name => "Domain filter";
 
         /// <inheritdoc />
-        public override Result ValidateEmailAddress(EmailAddress address)
+        public override Result ValidateEmailAddress(ref EmailAddress address)
         {
             var domain = address.Domain;
 

--- a/src/Objects/Filters/InvalidAddressFilter.cs
+++ b/src/Objects/Filters/InvalidAddressFilter.cs
@@ -25,7 +25,7 @@ namespace MyAddressExtractor.Objects.Filters {
         public override string Name => "Filter invalids";
 
         /// <inheritdoc />
-        public override Result ValidateEmailAddress(EmailAddress address)
+        public override Result ValidateEmailAddress(ref EmailAddress address)
             => this.Continue(!InvalidAddressFilter.InvalidEmailRegex()
                 .IsMatch(address.Full));
     }

--- a/src/Objects/Filters/InvalidAddressFilter.cs
+++ b/src/Objects/Filters/InvalidAddressFilter.cs
@@ -1,0 +1,32 @@
+using System.Text.RegularExpressions;
+using MyAddressExtractor.Objects.Attributes;
+
+namespace MyAddressExtractor.Objects.Filters {
+    /// <summary>
+    /// A negative-regex pattern for filtering out bad emails
+    /// </summary>
+    [AddressFilter(Priority = 800)]
+    public partial class InvalidAddressFilter : AddressFilter.BaseFilter {
+        /// <summary>
+        /// \.\.	Email having consecutive dot
+        /// \*	    Email having *
+        /// .@	    Email having .@
+        /// @-	    Email having @-
+        /// </summary>
+        [GeneratedRegex(
+            @"\.\.|\*|\.@|^\.|@-",
+            RegexOptions.ExplicitCapture // Require naming captures; implies '(?:)' on groups. We don't make use of the groups
+            | RegexOptions.IgnoreCase // Match upper and lower casing
+            | RegexOptions.Compiled // Compile the nodes
+            | RegexOptions.Singleline // Singleline mode
+        )]
+        public static partial Regex InvalidEmailRegex();
+
+        public override string Name => "Filter invalids";
+
+        /// <inheritdoc />
+        public override Result ValidateEmailAddress(EmailAddress address)
+            => this.Continue(!InvalidAddressFilter.InvalidEmailRegex()
+                .IsMatch(address.Full));
+    }
+}

--- a/src/Objects/Filters/LengthFilter.cs
+++ b/src/Objects/Filters/LengthFilter.cs
@@ -1,0 +1,13 @@
+using MyAddressExtractor.Objects.Attributes;
+
+namespace MyAddressExtractor.Objects.Filters {
+    [AddressFilter(Priority = 1000)]
+    public sealed class LengthFilter : AddressFilter.BaseFilter {
+        public override string Name => "Check length";
+
+        /// <inheritdoc />
+        public override Result ValidateEmailAddress(EmailAddress address)
+            // Use the match position to validate too long of a length so we don't have to allocate the substring
+            => this.Continue(address.Length <= 255);
+    }
+}

--- a/src/Objects/Filters/LengthFilter.cs
+++ b/src/Objects/Filters/LengthFilter.cs
@@ -6,7 +6,7 @@ namespace MyAddressExtractor.Objects.Filters {
         public override string Name => "Check length";
 
         /// <inheritdoc />
-        public override Result ValidateEmailAddress(EmailAddress address)
+        public override Result ValidateEmailAddress(ref EmailAddress address)
             // Use the match position to validate too long of a length so we don't have to allocate the substring
             => this.Continue(address.Length <= 255);
     }

--- a/src/Objects/Filters/QuotesFilter.cs
+++ b/src/Objects/Filters/QuotesFilter.cs
@@ -45,23 +45,26 @@ namespace MyAddressExtractor.Objects.Filters {
         {
             bool modified = false;
             foreach (object junk in QuotesFilter.JUNK_CHARS) {
-                int? len = null;
-                if (junk is string str)
-                {
-                    if (address.Full.StartsWith(str) && address.Full.EndsWith(str))
-                        len = str.Length;
-                }
-                else if (junk is char c)
-                {
-                    if (address.Full.StartsWith(c) && address.Full.EndsWith(c))
-                        len = 1;
-                }
+                int? len;
+                do {
+                    len = null;
+                    if (junk is string str)
+                    {
+                        if (address.Full.StartsWith(str) && address.Full.EndsWith(str))
+                            len = str.Length;
+                    }
+                    else if (junk is char c)
+                    {
+                        if (address.Full.StartsWith(c) && address.Full.EndsWith(c))
+                            len = 1;
+                    }
 
-                if (len is not null)
-                {
-                    address.Full = address.Full[(Range)(len..^len)];
-                    modified = true;
-                }
+                    if (len is not null)
+                    {
+                        address.Full = address.Full[(Range)(len..^len)];
+                        modified = true;
+                    }
+                } while (len is not null);
             }
 
             return modified;

--- a/src/Objects/Filters/QuotesFilter.cs
+++ b/src/Objects/Filters/QuotesFilter.cs
@@ -1,10 +1,16 @@
 namespace MyAddressExtractor.Objects.Filters {
     public sealed class QuotesFilter : AddressFilter.BaseFilter {
+        private static readonly object[] JUNK_CHARS = { '"', '\'', "\\\"" };
+
         public override string Name => "Filter quotes";
 
         /// <inheritdoc />
-        public override Result ValidateEmailAddress(EmailAddress address)
+        public override Result ValidateEmailAddress(ref EmailAddress address)
         {
+            // Clean up the address
+            if (this.Trim(ref address))
+                return Result.REVALIDATE;
+
             // Is there a single backslash enclosed in quotes? if yes, that's ok. A single backslash without quotes is not
             var username = address.Username;
 
@@ -31,6 +37,34 @@ namespace MyAddressExtractor.Objects.Filters {
 
             // Does it contain mismatched (an odd number) quotes?
             return this.Continue((unescapedQuoteCount & 1) != 1);
+        }
+
+        /// <summary>Remove matching junk opening and closing characters caught by the initial Regex</summary>
+        /// <returns>If TRUE will re-run previous filters with the changed value</returns>
+        private bool Trim(ref EmailAddress address)
+        {
+            bool modified = false;
+            foreach (object junk in QuotesFilter.JUNK_CHARS) {
+                int? len = null;
+                if (junk is string str)
+                {
+                    if (address.Full.StartsWith(str) && address.Full.EndsWith(str))
+                        len = str.Length;
+                }
+                else if (junk is char c)
+                {
+                    if (address.Full.StartsWith(c) && address.Full.EndsWith(c))
+                        len = 1;
+                }
+
+                if (len is not null)
+                {
+                    address.Full = address.Full[(Range)(len..^len)];
+                    modified = true;
+                }
+            }
+
+            return modified;
         }
     }
 }

--- a/src/Objects/Filters/QuotesFilter.cs
+++ b/src/Objects/Filters/QuotesFilter.cs
@@ -1,0 +1,36 @@
+namespace MyAddressExtractor.Objects.Filters {
+    public sealed class QuotesFilter : AddressFilter.BaseFilter {
+        public override string Name => "Filter quotes";
+
+        /// <inheritdoc />
+        public override Result ValidateEmailAddress(EmailAddress address)
+        {
+            // Is there a single backslash enclosed in quotes? if yes, that's ok. A single backslash without quotes is not
+            var username = address.Username;
+
+            // Handle quotes at the start and end of the username
+            if (username.StartsWith('\'') && username.EndsWith('\''))
+                username = username[1..^1];
+            if (username.StartsWith('"') && username.EndsWith('"'))
+                username = username[1..^1];
+            if (username.StartsWith("\\\"") && username.EndsWith("\\\""))
+                username = username[2..^2];
+
+            // Does the username contain any unescaped double quotes?
+            var quoteIndex = username.IndexOf('"');
+            var unescapedQuoteCount = 0;
+
+            while (quoteIndex != -1)
+            {
+                if (quoteIndex == 0 || (quoteIndex > 0 && username[quoteIndex - 1] != '\\'))
+                {
+                    unescapedQuoteCount++;
+                }
+                quoteIndex = username.IndexOf('"', quoteIndex + 1);
+            }
+
+            // Does it contain mismatched (an odd number) quotes?
+            return this.Continue((unescapedQuoteCount & 1) != 1);
+        }
+    }
+}

--- a/src/Objects/Filters/TldFilter.cs
+++ b/src/Objects/Filters/TldFilter.cs
@@ -3,7 +3,7 @@ namespace MyAddressExtractor.Objects.Filters {
         public override string Name => "TLD Filter";
 
         /// <inheritdoc />
-        public override Result ValidateEmailAddress(EmailAddress address)
+        public override Result ValidateEmailAddress(ref EmailAddress address)
             => Result.CONTINUE; // TODO: Implement a handler to check address.Domain's TLD
     }
 }

--- a/src/Objects/Filters/TldFilter.cs
+++ b/src/Objects/Filters/TldFilter.cs
@@ -1,0 +1,9 @@
+namespace MyAddressExtractor.Objects.Filters {
+    public sealed class TldFilter : AddressFilter.BaseFilter {
+        public override string Name => "TLD Filter";
+
+        /// <inheritdoc />
+        public override Result ValidateEmailAddress(EmailAddress address)
+            => Result.CONTINUE; // TODO: Implement a handler to check address.Domain's TLD
+    }
+}

--- a/src/Objects/Performance/DebugPerformanceStack.cs
+++ b/src/Objects/Performance/DebugPerformanceStack.cs
@@ -171,7 +171,7 @@ namespace MyAddressExtractor.Objects.Performance {
 
             public void Log(int left = 0, int right = 0)
             {
-                Console.WriteLine($"{new string(' ', left)} - {this.Name.PadRight(right)} x{this.Counter:n0} | Took {TimeUnitExtensions.Format(this.Span.TotalMilliseconds, TimeUnit.MILLISECONDS)} (at ~{TimeUnitExtensions.Format(this.Span.TotalMicroseconds / this.Counter)} per)");
+                Console.WriteLine($"{new string(' ', left)} - {this.Name.PadRight(right)} x{this.Counter:n0} | Took {this.Span.Format()} (at ~{TimeUnitExtensions.Format(this.Span.TotalMicroseconds / this.Counter)} per)");
             }
         }
     }

--- a/src/Objects/Performance/DebugPerformanceStack.cs
+++ b/src/Objects/Performance/DebugPerformanceStack.cs
@@ -171,7 +171,7 @@ namespace MyAddressExtractor.Objects.Performance {
 
             public void Log(int left = 0, int right = 0)
             {
-                Console.WriteLine($"{new string(' ', left)} - {this.Name.PadRight(right)} x{this.Counter:n0} | Took {this.Span.TotalMilliseconds:n0}ms (at ~{TimeUnitExtensions.Format(this.Span.TotalMicroseconds / this.Counter)} per)");
+                Console.WriteLine($"{new string(' ', left)} - {this.Name.PadRight(right)} x{this.Counter:n0} | Took {TimeUnitExtensions.Format(this.Span.TotalMilliseconds, TimeUnit.MILLISECONDS)} (at ~{TimeUnitExtensions.Format(this.Span.TotalMicroseconds / this.Counter)} per)");
             }
         }
     }

--- a/src/Objects/Result.cs
+++ b/src/Objects/Result.cs
@@ -4,10 +4,17 @@ namespace MyAddressExtractor.Objects {
         /// <summary>Your <see cref="AddressFilter.BaseFilter"/> is certain the the <see cref="EmailAddress"/> is VALID</summary>
         ALLOW,
 
+        /// <summary>Your <see cref="AddressFilter.BaseFilter"/> is certain that the <see cref="EmailAddress"/> is NOT VALID</summary>
+        DENY,
+
+        #region Special
+
         /// <summary>Your <see cref="AddressFilter.BaseFilter"/> is uncertain of the validity of the address</summary>
         CONTINUE,
 
-        /// <summary>Your <see cref="AddressFilter.BaseFilter"/> is certain that the <see cref="EmailAddress"/> is NOT VALID</summary>
-        DENY
+        /// <summary>Restarts all <see cref="AddressFilter.BaseFilter"/>s</summary>
+        REVALIDATE,
+
+        #endregion
     }
 }

--- a/src/Objects/Result.cs
+++ b/src/Objects/Result.cs
@@ -1,0 +1,12 @@
+namespace MyAddressExtractor.Objects {
+    public enum Result {
+        /// <summary>Your <see cref="AddressFilter.BaseFilter"/> is certain the the <see cref="EmailAddress"/> is VALID</summary>
+        ALLOW,
+
+        /// <summary>Your <see cref="AddressFilter.BaseFilter"/> is uncertain of the validity of the address</summary>
+        CONTINUE,
+
+        /// <summary>Your <see cref="AddressFilter.BaseFilter"/> is certain that the <see cref="EmailAddress"/> is NOT VALID</summary>
+        DENY
+    }
+}

--- a/src/Objects/Result.cs
+++ b/src/Objects/Result.cs
@@ -1,5 +1,6 @@
 namespace MyAddressExtractor.Objects {
-    public enum Result {
+    public enum Result
+    {
         /// <summary>Your <see cref="AddressFilter.BaseFilter"/> is certain the the <see cref="EmailAddress"/> is VALID</summary>
         ALLOW,
 

--- a/src/Objects/TimeUnit.cs
+++ b/src/Objects/TimeUnit.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace MyAddressExtractor.Objects {
     public enum TimeUnit : long {
         MICROSECONDS = 1,
@@ -43,7 +45,10 @@ namespace MyAddressExtractor.Objects {
                 }
             }
 
-            return $"{result:n0}{size.Format()}";
+            return $"{string.Format($"{{0:F{size.Decimals()}}}", result)}{size.Format()}";
         }
+
+        public static int Decimals(this TimeUnit unit)
+            => unit > TimeUnit.SECONDS ? 1 : 0;
     }
 }

--- a/src/Objects/TimeUnit.cs
+++ b/src/Objects/TimeUnit.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-
 namespace MyAddressExtractor.Objects {
     public enum TimeUnit : long {
         MICROSECONDS = 1,
@@ -9,7 +7,7 @@ namespace MyAddressExtractor.Objects {
         HOURS = MINUTES * 60,
         DAYS = HOURS * 24
     }
-    
+
     public static class TimeUnitExtensions
     {
         public static double Convert(this TimeUnit to, double fromAmount, TimeUnit from = TimeUnit.MILLISECONDS)
@@ -33,12 +31,14 @@ namespace MyAddressExtractor.Objects {
             var size = from;
             var result = fromAmount;
 
-            foreach (TimeUnit unit in Enum.GetValues<TimeUnit>().OrderDescending()) {
+            foreach (TimeUnit unit in Enum.GetValues<TimeUnit>().OrderDescending())
+            {
                 if (unit <= from || fromAmount < (long)unit)
                     continue;
                 var conversion = unit.Convert(fromAmount, from);
 
-                if (conversion > 0) {
+                if (conversion > 0)
+                {
                     size = unit;
                     result = conversion;
                     break;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -52,13 +52,23 @@ namespace MyAddressExtractor
 
                 await using (var monitor = new AddressExtractorMonitor(perf))
                 {
-                    await monitor.RunAsync(files, CancellationToken.None);
+                    foreach (var file in files)
+                    {
+                        try {
+                            await monitor.RunAsync(file, CancellationToken.None);
+
+                        } catch (Exception ex) {
+                            Console.Error.WriteLine($"An error occurred while reading '{file}': {ex.Message}");
+                            if (ex is not NotImplementedException && !config.WaitContinue())
+                                return (int)ErrorCode.UnspecifiedError;
+                        }
+                    }
 
                     // Log one last time out of the Timer loop
                     monitor.Log();
                     await monitor.SaveAsync(config, CancellationToken.None);
                 }
-                
+
                 Console.WriteLine($"Addresses saved to {config.OutputFilePath}");
                 Console.WriteLine($"Report saved to {config.ReportFilePath}");
             }

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -101,6 +101,22 @@ namespace AddressExtractorTest
         }
 
         [TestMethod]
+        public async Task EmailAddressInQuotesAreExtracted()
+        {
+            const string INPUT = """
+                "test1@example.com"
+                ""test2@example.com""
+                'test3@example.com'
+                \"test4@example.com\"
+                "test5"@example.com
+                test6"@example.com
+            """;
+
+            var result = await this.ExtractAddressesAsync(INPUT);
+            throw new NotImplementedException($"A proper count from {nameof(result)} needs to be found");
+        }
+
+        [TestMethod]
         public async Task LineBreakShouldNotHaltProcessing()
         {
             // Arrange

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -12,7 +12,7 @@ namespace AddressExtractorTest
             var result = await this.ExtractAddressesFromFileAsync(@"../../../../TestData/SingleFile/SingleSmallFile.txt");
 
             // Assert
-            Assert.IsTrue(result.Count == 12, "12 email addresses should be found");
+            Assert.IsTrue(result.Count == 12, $"12 email addresses should be found, found {result.Count}");
         }     
         
         [TestMethod]
@@ -25,26 +25,26 @@ namespace AddressExtractorTest
         }
 
         [TestMethod]
-        public void EmailAddressesAreNotCaseSensitive()
+        public async Task EmailAddressesAreNotCaseSensitive()
         {
             const string ADDRESSES = "test@example.com TEST@EXAMPLE.COM";
 
             // Act
-            var result = this.ExtractAddresses(ADDRESSES);
+            var result = await this.ExtractAddressesAsync(ADDRESSES);
 
             // Assert
             Assert.IsTrue(result.Count == 1, "Same addresses of different case should be merged");
         }
 
         [TestMethod]
-        public void EmailAddressesAreConvertedToLowercase()
+        public async Task EmailAddressesAreConvertedToLowercase()
         {
             // Arrange
             const string INPUT = "TEST@EXAMPLE.COM";
             const string EXPECTED = "test@example.com";
 
             // Act
-            var result = this.ExtractAddresses(INPUT);
+            var result = await this.ExtractAddressesAsync(INPUT);
 
             result.Add(EXPECTED);
 
@@ -53,14 +53,14 @@ namespace AddressExtractorTest
         }
 
         [TestMethod]
-        public void EmailAddressesInSingleQuotesIsExtracted()
+        public async Task EmailAddressesInSingleQuotesIsExtracted()
         {
             // Arrange
             const string INPUT = "'test@example.com'";
             const string EXPECTED = "test@example.com";
 
             // Act
-            var result = this.ExtractAddresses(INPUT);
+            var result = await this.ExtractAddressesAsync(INPUT);
 
             result.Add(EXPECTED);
 
@@ -69,14 +69,14 @@ namespace AddressExtractorTest
         }
 
         [TestMethod]
-        public void EmailAddressesInDoubleQuotesIsExtracted()
+        public async Task EmailAddressesInDoubleQuotesIsExtracted()
         {
             // Arrange
             const string INPUT = "\"test@example.com\"";
             const string EXPECTED = "test@example.com";
 
             // Act
-            var result = this.ExtractAddresses(INPUT);
+            var result = await this.ExtractAddressesAsync(INPUT);
 
             result.Add(EXPECTED);
 
@@ -85,14 +85,14 @@ namespace AddressExtractorTest
         }
 
         [TestMethod]
-        public void EmailAddressesInEscapedDoubleQuotesIsExtracted()
+        public async Task EmailAddressesInEscapedDoubleQuotesIsExtracted()
         {
             // Arrange
             const string INPUT = "\\\"test@example.com\\\"";
             const string EXPECTED = "test@example.com";
 
             // Act
-            var result = this.ExtractAddresses(INPUT);
+            var result = await this.ExtractAddressesAsync(INPUT);
 
             result.Add(EXPECTED);
 
@@ -101,7 +101,7 @@ namespace AddressExtractorTest
         }
 
         [TestMethod]
-        public void LineBreakShouldNotHaltProcessing()
+        public async Task LineBreakShouldNotHaltProcessing()
         {
             // Arrange
             const string INPUT = """
@@ -112,7 +112,7 @@ namespace AddressExtractorTest
             const string EXPECTED = "test@example.com";
 
             // Act
-            var result = this.ExtractAddresses(INPUT);
+            var result = await this.ExtractAddressesAsync(INPUT);
 
             result.Add(EXPECTED);
 
@@ -121,46 +121,46 @@ namespace AddressExtractorTest
         } 
 
         [TestMethod]
-        public void EmailAddressesCannotHaveDomainStartingWithHyphen()
+        public async Task EmailAddressesCannotHaveDomainStartingWithHyphen()
         {
             // Arrange
             const string INPUT = "test@-example.com";
 
             // Act
-            var result = this.ExtractAddresses(INPUT);
+            var result = await this.ExtractAddressesAsync(INPUT);
 
             // Assert
             Assert.IsFalse(result.Any(), "No results should be returned");
         }    
 
         [TestMethod]
-        public void EmailAddressesCannotHaveDomainEndingWithHyphen()
+        public async Task EmailAddressesCannotHaveDomainEndingWithHyphen()
         {
             // Arrange
             const string INPUT = "test@example-.com";
 
             // Act
-            var result = this.ExtractAddresses(INPUT);
+            var result = await this.ExtractAddressesAsync(INPUT);
 
             // Assert
             Assert.IsFalse(result.Any(), "No results should be returned");
         }
 
         [TestMethod]
-        public void EmailAddressesWithKnownFileExtensionsThatAreNotTldsAreIgnored()
+        public async Task EmailAddressesWithKnownFileExtensionsThatAreNotTldsAreIgnored()
         {
             // Arrange
             const string INPUT = "test@example.jpg";
 
             // Act
-            var result = this.ExtractAddresses(INPUT);
+            var result = await this.ExtractAddressesAsync(INPUT);
 
             // Assert
             Assert.IsFalse(result.Any(), "No results should be returned");
         }
 
         [TestMethod]
-        public void CommaShouldTerminateAddress()
+        public async Task CommaShouldTerminateAddress()
         {
             // Arrange
             const string INPUT = "email1@example.com,email2@example.com";
@@ -168,7 +168,7 @@ namespace AddressExtractorTest
             const string EXPECTED_LAST = "email2@example.com";
 
             // Act
-            var result = this.ExtractAddresses(INPUT);
+            var result = await this.ExtractAddressesAsync(INPUT);
 
             // Assert
             Assert.IsTrue(result.Count == 2, "Two results should be returned");
@@ -178,13 +178,13 @@ namespace AddressExtractorTest
 
         [TestMethod]
         [Ignore("This is a low priority feature so the test is ignored for the moment in the interests of having all green all the way for tests that *should* be working now")]
-        public void AliasOnEmojiDomainIsFound()
+        public async Task AliasOnEmojiDomainIsFound()
         {
           // Arrange
           const string INPUT = "example@i❤️.ws is";
 
           // Act
-          var result = this.ExtractAddresses(INPUT);
+          var result = await this.ExtractAddressesAsync(INPUT);
 
           // Assert
           Assert.IsTrue(result.Any(), "A result should be returned");
@@ -192,13 +192,13 @@ namespace AddressExtractorTest
 
         [TestMethod]
         [Ignore("This is a low priority feature so the test is ignored for the moment in the interests of having all green all the way for tests that *should* be working now")]
-        public void EmailAddressOnIdnDomainNameIsRecognised()
+        public async Task EmailAddressOnIdnDomainNameIsRecognised()
         {
           // Arrange
           const string INPUT = "بريد@موقع.شبكة";
 
           // Act
-          var result = this.ExtractAddresses(INPUT);
+          var result = await this.ExtractAddressesAsync(INPUT);
 
           // Assert
           Assert.IsTrue(result.Any(), "A result should be returned");
@@ -211,11 +211,14 @@ namespace AddressExtractorTest
         /// Wrapping the <see cref="IEnumerable{String}"/> here instead of within the Method
         /// prevents the overhead of creating a Set for every iteration in Production
         /// </summary>
-        private HashSet<string> ExtractAddresses(string input)
+        private async ValueTask<HashSet<string>> ExtractAddressesAsync(string input)
         {
             var extractor = new AddressExtractor();
             var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            set.UnionWith(extractor.ExtractAddresses(input));
+
+            await foreach(var address in extractor.ExtractAddressesAsync(input))
+                set.Add(address);
+
             return set;
         }
 
@@ -228,7 +231,7 @@ namespace AddressExtractorTest
 
             await using (var reader = parser.GetReader(path))
             {
-                await foreach(var address in extractor.ExtractAddressesAsync(reader, cancellation))
+                await foreach(var address in extractor.ExtractFileAddressesAsync(reader, cancellation))
                     set.Add(address);
             }
             return set;

--- a/test/LegacyTests.cs
+++ b/test/LegacyTests.cs
@@ -9,140 +9,140 @@ namespace AddressExtractorTest
         #region Valid addresses
 
         [TestMethod]
-        public void AmpersandIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"Mary&Jane@example.org"));
+        public async Task AmpersandIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"Mary&Jane@example.org"));
 
         [TestMethod]
-        public void SingleBackslashEnclosedInQuotesIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"""test\""blah""@example.com"));
+        public async Task SingleBackslashEnclosedInQuotesIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"""test\""blah""@example.com"));
 
         [TestMethod]
-        public void ForwardSlashIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"customer/department@example.com"));
+        public async Task ForwardSlashIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"customer/department@example.com"));
 
         [TestMethod]
-        public void StartingWithDollarSignIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"$A12345@example.com"));
+        public async Task StartingWithDollarSignIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"$A12345@example.com"));
 
         [TestMethod]
-        public void StartingWithExclamationMarkIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"!def!xyz%abc@example.com"));
+        public async Task StartingWithExclamationMarkIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"!def!xyz%abc@example.com"));
 
         [TestMethod]
-        public void StartingWithUnderscoreIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"_Yosemite.Sam@example.com"));
+        public async Task StartingWithUnderscoreIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"_Yosemite.Sam@example.com"));
 
         [TestMethod]
-        public void DotInAliasIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"Ima.Fool@example.com"));
+        public async Task DotInAliasIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"Ima.Fool@example.com"));
 
         [TestMethod]
-        public void SingleCharDomainIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"foobar@x.com"));
+        public async Task SingleCharDomainIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"foobar@x.com"));
 
         [TestMethod]
-        public void DomainWithNumberIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"foobar@c0m.com"));
+        public async Task DomainWithNumberIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"foobar@c0m.com"));
 
         [TestMethod]
-        public void DomainWithUnderscoreIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"foobar@c_m.com"));
+        public async Task DomainWithUnderscoreIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"foobar@c_m.com"));
 
         [TestMethod]
-        public void DomainWithUnderscoreBeforeTldIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"foo@bar_.com"));
+        public async Task DomainWithUnderscoreBeforeTldIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"foo@bar_.com"));
 
         [TestMethod]
-        public void DomainWithNumbersOnlyIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"foo@666.com"));
+        public async Task DomainWithNumbersOnlyIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"foo@666.com"));
 
         [TestMethod]
-        public void EmailOf255CharsIsValid()
-            => Assert.IsTrue(this.IsValidEmail(@"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com"));
+        public async Task EmailOf255CharsIsValid()
+            => Assert.IsTrue(await this.IsValidEmailAsync(@"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com"));
 
         #endregion
         #region Invalid addresses
 
         [TestMethod]
-        public void NullIsInvalid()
-        => Assert.IsFalse(this.IsValidEmail(null));
+        public async Task NullIsInvalid()
+        => Assert.IsFalse(await this.IsValidEmailAsync(null));
 
         [TestMethod]
-        public void EmptyEmailIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail(string.Empty));
+        public async Task EmptyEmailIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync(string.Empty));
 
         [TestMethod]
-        public void NoAtSymbolIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail("NotAnEmail"));
+        public async Task NoAtSymbolIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("NotAnEmail"));
 
         [TestMethod]
-        public void AtFirstIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail("@NotAnEmail"));
+        public async Task AtFirstIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("@NotAnEmail"));
 
         [TestMethod]
-        public void AtLastIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail("NotAnEmail@"));
+        public async Task AtLastIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("NotAnEmail@"));
 
         [TestMethod]
-        public void BackspaceCharIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail("foo@b" + (char)8 + "ar.com"));
+        public async Task BackspaceCharIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("foo@b" + (char)8 + "ar.com"));
 
         [TestMethod]
-        public void HorizontalTabCharIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail("foo@b" + (char)9 + "ar.com"));
+        public async Task HorizontalTabCharIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("foo@b" + (char)9 + "ar.com"));
 
         [TestMethod]
-        public void DeleteCharIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail("foo@b" + (char)127 + "ar.com"));
+        public async Task DeleteCharIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("foo@b" + (char)127 + "ar.com"));
 
         [TestMethod]
         [Ignore("This is a low priority feature so the test is ignored for the moment in the interests of having all green all the way for tests that *should* be working now")]
-        public void AliasWithAsteriskIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail(@"fo*o@bar.com"));
+        public async Task AliasWithAsteriskIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync(@"fo*o@bar.com"));
 
         [TestMethod]
-        public void EmailOf256CharsIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail(@"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com"));
+        public async Task EmailOf256CharsIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync(@"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111@example.com"));
 
         [TestMethod]
-        public void UnescapedDoubleQuoteIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail("\"test\rblah\"@example.com"));
+        public async Task UnescapedDoubleQuoteIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("\"test\rblah\"@example.com"));
 
         [TestMethod]
-        public void DotFirstIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail(@".wooly@example.com"));
+        public async Task DotFirstIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync(@".wooly@example.com"));
 
         [TestMethod]
-        public void ConsecutiveDotsIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail(@"wo..oly@example.com"));
+        public async Task ConsecutiveDotsIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync(@"wo..oly@example.com"));
 
         [TestMethod]
-        public void DotBeforeAtIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail(@"pootietang.@example.com"));
+        public async Task DotBeforeAtIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync(@"pootietang.@example.com"));
 
         [TestMethod]
-        public void DotForAliasIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail(@".@example.com"));
+        public async Task DotForAliasIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync(@".@example.com"));
 
         [TestMethod]
-        public void NoDotInDomainIsInvalid()
-            => Assert.IsFalse(this.IsValidEmail(@"foo@bar"));
+        public async Task NoDotInDomainIsInvalid()
+            => Assert.IsFalse(await this.IsValidEmailAsync(@"foo@bar"));
 
         [TestMethod]
-        public void TldStartingWithNumberIsNotValid()
-            => Assert.IsFalse(this.IsValidEmail("foo@bar.1com"));
+        public async Task TldStartingWithNumberIsNotValid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("foo@bar.1com"));
 
         [TestMethod]
-        public void TldWithOnlyNumbersIsNotValid()
-            => Assert.IsFalse(this.IsValidEmail("foo@bar.123"));
+        public async Task TldWithOnlyNumbersIsNotValid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("foo@bar.123"));
 
         [TestMethod]
-        public void TldWithOneCharacterIsNotValid()
-            => Assert.IsFalse(this.IsValidEmail("foo@bar.a"));
+        public async Task TldWithOneCharacterIsNotValid()
+            => Assert.IsFalse(await this.IsValidEmailAsync("foo@bar.a"));
 
         [TestMethod]
-        public void DomainWithUnderscoreOnlyIsNotValid()
-            => Assert.IsFalse(this.IsValidEmail(@"foobar@_.com"));
+        public async Task DomainWithUnderscoreOnlyIsNotValid()
+            => Assert.IsFalse(await this.IsValidEmailAsync(@"foobar@_.com"));
 
         #endregion
 
@@ -151,11 +151,12 @@ namespace AddressExtractorTest
         /// </summary>
         /// <param name="sourceEmail"></param>
         /// <returns></returns>
-        private bool IsValidEmail(string? sourceEmail)
+        private async ValueTask<bool> IsValidEmailAsync(string? sourceEmail)
         {
             var sut = new AddressExtractor();
-            var result = sut.ExtractAddresses(sourceEmail);
-            return result.Any();
+            await foreach (var _ in sut.ExtractAddressesAsync(sourceEmail))
+                return true;
+            return false;
         }
     }
 }


### PR DESCRIPTION
This is kind of a big change, but I refactored `AddressExtractor.cs` so it wasn't such a hot path for contributors.

Since extracting email addresses is the bread and butter of the operation, having everyone tweaking it constantly leads to a lot of merge conflicts, already extremely so with a small-ish amount of contributors.

This PR works to change `AddressExtractor` so that it doesn't need to be directly modified.

----

I created a class called `BaseFilter`, which is an abstract base for allowing contributors to create their own address Filters. `AddressExtractor` still contains the main Regex for capturing what an email is, but filters can do filtering operations where Regex catches false positives.

The filter method implements two Methods:

```csharp
virtual Result ValidateEmailAddress(EmailAddress address)
    => Result.CONTINUE;

virtual ValueTask<Result> ValidateEmailAddressAsync(EmailAddress address, CancellationToken cancellation = default)
    => ValueTask.FromResult(this.ValidateEmailAddress(address));
```

If for some reason a Filter needs to run asynchronously it can, as the Async method is what is called by the `AddressExtractor`. A contributor can override either method to create their filter.

----

The Address Filter returns a `Result` Enum:

```csharp
enum Result
{
    ALLOW,
    CONTINUE,
    DENY
}
```

`ALLOW` isn't of much use, but if a Filter wants to declare that a string should immediately succeed, it can do so. `CONTINUE` means that it passes the filter, and will continue to run through the remaining filters, and `DENY` fails the string as not a valid address.

I've moved all of the current filters from the `for` loop into their own filters:
- DomainFilter.cs
- InvalidAddressFilter.cs
- LengthFilter.cs
- QuotesFilter.cs
- TldFilter.cs

----

With this change I appear to have broken the test `AddressExtractorTests.CorrectNumberOfAddressesAreExtractedFromFile()`? It's reading 11 address from `SingleSmallFile.txt` when it expects 12.

One of the following addresses should succeed but I'm not sure which one?

```
Failed 'Filter quotes': '"test3@example.com"'
Failed 'Check length': 'teeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee10@example.com'
Failed 'Domain filter': 'test11@192.168'
```