### PR TITLE
Fixed README Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The regex I've used is as follows: `\b[a-zA-Z0-9\.\-_\+]+@[a-zA-Z0-9\.\-_]+\.[a-
 
 # Test data
 
-Using Red Gate's SQL Data Generator, [a sample file containing 10M records of typical breach data is available do download from Mega]([url](https://mega.nz/file/Ls8U1ADK#c1We1C_CZi44P0k3OB8YpNVN7HMM3gE_4-fH06E454c)).
+Using Red Gate's SQL Data Generator, [a sample file containing 10M records of typical breach data is available to download from Mega](https://mega.nz/file/Ls8U1ADK#c1We1C_CZi44P0k3OB8YpNVN7HMM3gE_4-fH06E454c).
 
 # Running the Address Extractor
 
@@ -38,4 +38,4 @@ Syntax: `AddressExtractor.exe <input [[... input]]> [-o output] [-r report]`
 | `-r`, `--report` report | Path and filename of the report file. Defaults to 'report.txt'             |
 | `--recursive`           | Enable recursive mode for directories, which will search child directories |
 | `-y`, `--yes`           | Automatically confirm prompts to CONTINUE without asking                   |
-| `--debug`               | Enabled debug mode for fine-tuned performance checking                     |
+| `--debug`               | Enable debug mode for fine-tuned performance checking                     |


### PR DESCRIPTION
The URL to the sample file wasn't showing in the README

Changed formatting from `[text]([text](url))` to `[text](url)`