### PR TITLE
Refactored ILineReader slightly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ There are a number of TestMethods available in the `AddressExtractorTest` namesp
 
 Please make sure to use the `--debug` command-line option to test your changes. Being able to quickly run through a data dump is best!
 
-### File Extensions
+### File Extensions / File Types
 
 The Email Extractor is built for extracting Email Addresses from strings, but first it must be able to read those strings from files! These files mostly come from data dumps that aren't always in the prettiest format.
 
@@ -30,9 +30,12 @@ public interface ILineReader : IAsyncDisposable
 }
 ```
 
-You can create a new Reader class like so:
+You can create a new Reader class using the example below (**File readers are automatically picked up by the application using reflection**<sub>1</sub>). You can specify which file extensions your Reader class supports by using an `ExtensionTypesAttribute`, the Attribute must be provided the extensions that your reader supports in order for it to be used.
+
+- <sub>1</sub> Reflection will pick a constructor that accepts a string for the file path.
 
 ```csharp
+[ExtensionTypes(".extension", ".someotherextension")]
 public sealed class MyFileReader : ILineReader
 {
     private readonly string File;
@@ -62,26 +65,45 @@ public sealed class MyFileReader : ILineReader
 }
 ```
 
-After we create our `ILineReader` class, we need to add it to our `~/FileExtensionParsing.cs`:
+### Regex
+
+After reading content from files, the main address extractor in `src/AddressExtractor.cs` does a loose Regex matching of text that contains an email, and then uses Filters to update and validate the captured strings.
+
+### Filtering
+
+Filters can be created (and typically found in `src/Objects/Filters`) by creating a class that extends `AddressFilter.BaseFilter`.
+
+`BaseFilter` has two primary Methods (`ValidateEmailAddress` and `ValidateEmailAddressAsync`) and a Property (`Name`). The Name Property is logged when running in `--debug` mode.
+
+- When implementing a new Filter, either the async method or non-async can be overridden.
+- Applying the `AddressFilterAttribute` to your Filter allows you to set a `Priority`, higher priority filters will run before lower priority filters
+- Unlike `ILineReader` only one Filter object is constructed when the program starts
 
 ```csharp
-static FileExtensionParsing()
+[AddressFilter(Priority = 0)]
+public sealed class MyFilter : AddressFilter.BaseFilter
 {
-    /* ... */
-    
-    extensions.AddAll(
-        // Provide all of the supported extension types our reader can handle
-        new[] { ".txt", ".json", ".html" },
+    public override string Name => "My Filter";
+
+    // Validating an Email Address returns a 'Result', the 'Result' controls
+    //     how the filtering is handled.
+    // - Returning 'CONTINUE' will continue running through the remaining filters
+    //     until all filters have been passed
+    // - Returning 'REVALIDATE' will cause all filters to re-run again, this
+    //     is useful if you've updated the EmailAddress value
+    // - Returning 'ALLOW' will end filtering, and add the EmailAddress value
+    //     into the final result
+    // - Returning 'DENY' means that the EmailAddress is not a valid email and
+    //     will not be in the final result
+    // - BaseFilter provides a 'Continue' method that will convert a bool to
+    //     'Result', true is 'CONTINUE' and false is 'DENY'
+    public override Result ValidateEmailAddress(ref EmailAddress address)
+    {
+        // Here in the body you can access part of the EmailAddress for filtering
+        //   'address.Full' can also be updated if the email needs to be trimmed
+        //   If you update 'address.Full' you should return 'REVALIDATE' to re-run filters
         
-        // Here we create the information object
-        new FileExtensionParsing {
-            // The information object holds a 'Reader' Function
-            // This is the constructor that returns your 'ILineReader'
-            // A new Reader is created for every 'path'
-            Reader = path => new MyFileReader(path)
-        }
-    );
-    
-    /* ... */
+        return Result.CONTINUE;
+    }
 }
 ```

--- a/src/FileExtensionParsing.cs
+++ b/src/FileExtensionParsing.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Reflection;
+using MyAddressExtractor.Objects.Attributes;
 using MyAddressExtractor.Objects.Readers;
 
 namespace MyAddressExtractor {
@@ -8,113 +10,125 @@ namespace MyAddressExtractor {
         private static readonly FileExtensionParsing UNKNOWN = new() { Error = "Unknown Extension" };
         static FileExtensionParsing() {
             var extensions = new ConcurrentDictionary<string, FileExtensionParsing>(StringComparer.OrdinalIgnoreCase);
-            
-            // Accepted plaintext files
-            extensions.AddAll(
-                new[] { ".log", ".json", ".txt", ".sql", ".xml", ".sample", ".csv", ".tsv" },
-                new FileExtensionParsing {
-                    Reader = path => new PlainTextReader(path)
-                    // No error means OK!
-                }
-            );
-            
+
             // Archives
             extensions.AddAll(
                 new[] { ".tar", ".gz", ".zip", ".rar", ".7z" },
                 new FileExtensionParsing { Error = "Archive files" }
             );
-            
+
             // Images
             extensions.AddAll(
                 new[] { ".png", ".tif", ".jpg", ".jpeg", ".gif", ".bmp", ".ai", ".psd", ".svg", ".ico" },
                 new FileExtensionParsing { Error = "Image files" }
             );
-            
+
             // AudioVideo
             extensions.AddAll(
                 new[] { ".rec", ".mp3", ".wav", ".mp4", ".mpg", ".mov", ".wmv", ".avi", ".m4v" },
                 new FileExtensionParsing { Error = "Audio/Video files" }
             );
-            
+
             // Sql
             extensions.AddAll(
                 new[] { ".frm", ".ibd", ".myi", ".myd" },
                 new FileExtensionParsing { Error = "Sql files" }
             );
-            
+
             // Code
             extensions.AddAll(
                 new[] { ".go", ".py", ".js", ".yml", ".php", ".c", ".sh", ".css", ".less", ".npmignore", ".groovy", ".scala", ".sass", ".ascx", ".markdown", ".bash", ".sln", ".h", ".ts", ".cs", ".aspx", ".csproj", ".nupk", ".suo", ".asax", ".resx", ".refesh", ".ipch" },
                 new FileExtensionParsing { Error = "Code files" }
             );
-            
+
             // Source Control
             extensions.AddAll(
                 new[] { ".svn-base", ".gitignore", ".gitattributes", ".pack" },
                 new FileExtensionParsing { Error = "Source-control files" }
             );
-            
+
             // Executables
             extensions.AddAll(
                 new[] { ".exe", ".dll", ".apk", ".jar", ".java",  "bin" },
                 new FileExtensionParsing { Error = "Executables" }
             );
-            
+
             // Other
             extensions.AddAll(
                 new[] { ".msi", ".flv", ".swf", ".pdb", ".brd", ".hprof", ".lock", ".docker", ".ttf", ".woff", ".woff2", ".pem", ".crt" },
                 new FileExtensionParsing { Error = "Unsupported" }
             );
-            
-            // Open Document - ISO 26300
+
+            // A set of all extensions that should be eventually supported
+            // These are overriden using Reflection and do not need to be removed
             extensions.AddAll(
-                new[] { ".odt" },
-                new FileExtensionParsing { Reader = path => new OpenDocumentXmlReader(path) }
-            );
-            
-            // Open Office XML - ISO 29500
-            extensions.AddAll(
-                new[] { ".docx", ".pptx" },
-                new FileExtensionParsing { Reader = path => new OpenOfficeXmlReader(path) }
-            );
-            
-            // Future
-            extensions.AddAll(
-                new[] { ".xls", ".doc", ".ppt", ".pdf", ".rdb" },
+                new[] { ".log", ".json", ".txt", ".sql", ".xml", ".sample", ".csv", ".tsv", ".odt", ".docx", ".pptx", ".xls", ".doc", ".ppt", ".pdf", ".rdb" },
                 new FileExtensionParsing { Error = "Not currently supported" }
             );
-            
+
+            var types = Assembly.GetExecutingAssembly()
+                .GetTypes()
+                .Where(type => type.IsClass && !type.IsAbstract && type.IsAssignableTo(typeof(ILineReader)));
+            foreach (var type in types)
+            {
+                if (type.GetCustomAttribute<ExtensionTypesAttribute>() is {} attribute)
+                {
+                    var parsing = new FileExtensionParsing {
+                        Reader = file => FileExtensionParsing.CreateInstance(type, file)
+                    };
+
+                    // Use the setter to override any other instances
+                    foreach (string extension in attribute.Extensions)
+                        extensions[extension] = parsing;
+                }
+            }
+
             FileExtensionParsing.FILE_EXTENSIONS = extensions;
         }
-        
+
         public bool Read => this.Error is null;
         public string? Error { get; init; } = null;
-        
+
         private ReaderDelegate? Reader { get; init; } = null;
-        
-        public ILineReader GetReader(string path) {
+
+        public ILineReader GetReader(string path)
+        {
             if (!this.Read)
                 throw new Exception("Cannot read files of this type");
             return this.Reader?.Invoke(path) ?? throw new NullReferenceException($"A {typeof(ILineReader)} could not be created for files of this type");
         }
-        
+
         #region Static Accessors
-        
+
         public static FileExtensionParsing Get(string extension)
             => FileExtensionParsing.FILE_EXTENSIONS.GetValueOrDefault(extension, FileExtensionParsing.UNKNOWN);
-        
+
         public static FileExtensionParsing Get(FileInfo info)
             => FileExtensionParsing.FILE_EXTENSIONS.GetValueOrDefault(info.Extension, FileExtensionParsing.UNKNOWN);
-        
+
         public static FileExtensionParsing GetFromPath(string path)
             => FileExtensionParsing.FILE_EXTENSIONS.GetValueOrDefault(Path.GetExtension(path), FileExtensionParsing.UNKNOWN);
-        
+
+        private static ILineReader CreateInstance(Type type, string path)
+        {
+            ConstructorInfo? info = type.GetConstructor(new []{ typeof(string) });
+
+            if (info?.Invoke(new object[] { path }) is ILineReader readerWithPath)
+                return readerWithPath;
+
+            info = type.GetConstructor(Array.Empty<Type>());
+            if (info?.Invoke(Array.Empty<object>()) is ILineReader reader)
+                return reader;
+
+            throw new NotSupportedException($"Could not find a valid constructor for {type}");
+        }
+
         /// <summary>
         /// A delegate for constructing a <see cref="ILineReader"/> capable of reading <see cref="string"/>s from a <see cref="path"/>
         /// When called, <see cref="path"/> is an existing system File
         /// </summary>
         private delegate ILineReader ReaderDelegate(string path);
-        
+
         #endregion
     }
 }

--- a/src/Objects/AddressFilter.cs
+++ b/src/Objects/AddressFilter.cs
@@ -26,7 +26,8 @@ namespace MyAddressExtractor.Objects {
         /// Instances of <see cref="BaseFilter"/> are created automatically using Reflection when the program starts
         /// A priority for the Filter can be applied using a <see cref="AddressFilterAttribute"/>
         /// </summary>
-        public abstract class BaseFilter {
+        public abstract class BaseFilter
+        {
             /// <summary>A Name for the Filter, which is added to the Debug Stack when run</summary>
             public abstract string Name { get; }
 
@@ -41,7 +42,8 @@ namespace MyAddressExtractor.Objects {
                 => success ? Result.CONTINUE : Result.DENY;
         }
 
-        private sealed class FilterCollection : IEnumerable<BaseFilter> {
+        private sealed class FilterCollection : IEnumerable<BaseFilter>
+        {
             /// <summary>Use a List so that we maintain entry order</summary>
             private readonly IList<BaseFilter> Filters = new List<BaseFilter>();
 

--- a/src/Objects/Attributes/ExtensionTypesAttribute.cs
+++ b/src/Objects/Attributes/ExtensionTypesAttribute.cs
@@ -1,0 +1,12 @@
+namespace MyAddressExtractor.Objects.Attributes {
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public sealed class ExtensionTypesAttribute : Attribute
+    {
+        public readonly string[] Extensions;
+
+        public ExtensionTypesAttribute(params string[] extensions)
+        {
+            this.Extensions = extensions;
+        }
+    }
+}

--- a/src/Objects/Readers/DocumentReader.cs
+++ b/src/Objects/Readers/DocumentReader.cs
@@ -1,4 +1,7 @@
+using MyAddressExtractor.Objects.Attributes;
+
 namespace MyAddressExtractor.Objects.Readers {
+    [ExtensionTypes(".doc")]
     public sealed class DocumentReader : ILineReader
     {
         /// <inheritdoc />

--- a/src/Objects/Readers/OpenDocumentXmlReader.cs
+++ b/src/Objects/Readers/OpenDocumentXmlReader.cs
@@ -1,5 +1,9 @@
+using MyAddressExtractor.Objects.Attributes;
+
 namespace MyAddressExtractor.Objects.Readers
 {
+    /// <summary>Open Document - ISO 26300</summary>
+    [ExtensionTypes(".odt")]
     internal sealed class OpenDocumentXmlReader : CompressedXmlReader
     {
         public OpenDocumentXmlReader(string zipPath) : base(zipPath)

--- a/src/Objects/Readers/OpenOfficeXmlReader.cs
+++ b/src/Objects/Readers/OpenOfficeXmlReader.cs
@@ -1,15 +1,21 @@
 using System.Text.RegularExpressions;
+using MyAddressExtractor.Objects.Attributes;
 
 namespace MyAddressExtractor.Objects.Readers
 {
-    internal sealed class OpenOfficeXmlReader : CompressedXmlReader
+    /// <summary>Open Office XML - ISO 29500</summary>
+    [ExtensionTypes(".docx", ".pptx")]
+    internal sealed partial class OpenOfficeXmlReader : CompressedXmlReader
     {
-        private Regex slideNameRegex = new Regex(@"(word/document\.xml|ppt/slides/slide(\d*)\.xml)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        [GeneratedRegex(@"(word/document\.xml|ppt/slides/slide(\d*)\.xml)", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+        private static partial Regex SlideNameRegex();
 
         public OpenOfficeXmlReader(string zipPath) : base(zipPath)
         {
         }
 
-        public override bool IsMatch(string entry) => slideNameRegex.IsMatch(entry);
+        public override bool IsMatch(string entry)
+            => OpenOfficeXmlReader.SlideNameRegex()
+                .IsMatch(entry);
     }
 }

--- a/src/Objects/Readers/PdfReader.cs
+++ b/src/Objects/Readers/PdfReader.cs
@@ -1,4 +1,7 @@
+using MyAddressExtractor.Objects.Attributes;
+
 namespace MyAddressExtractor.Objects.Readers {
+    [ExtensionTypes(".pdf")]
     public sealed class PdfReader : ILineReader
     {
         /// <inheritdoc />

--- a/src/Objects/Readers/PlainTextReader.cs
+++ b/src/Objects/Readers/PlainTextReader.cs
@@ -1,7 +1,9 @@
 using System.Runtime.CompilerServices;
 using System.Text;
+using MyAddressExtractor.Objects.Attributes;
 
 namespace MyAddressExtractor.Objects.Readers {
+    [ExtensionTypes(".log", ".json", ".txt", ".sql", ".xml", ".sample", ".csv", ".tsv")]
     internal sealed class PlainTextReader : ILineReader
     {
         private readonly FileStream FileStream;


### PR DESCRIPTION
Just like how I implemented Filters to automatically be found using Reflection, I changed implementations of `ILineReader` to be found using Reflection using the `ExtensionTypesAttribute`:

```csharp
[ExtensionTypes(".odt")]
internal sealed class OpenDocumentXmlReader : CompressedXmlReader
{ /* Stuff */ }
```

```csharp
[ExtensionTypes(".log", ".json", ".txt", ".sql", ".xml", ".sample", ".csv", ".tsv")]
internal sealed class PlainTextReader : ILineReader
{ /* Stuff */ }
```

```csharp
[ExtensionTypes(".pdf")]
public sealed class PdfReader : ILineReader
{ /* Stuff */ }
```

Now line reader files are self-contained and modifying `FileExtensionParsing.cs` isn't necessary.

I also added documentation for creating Filters to the `CONTRIBUTING.md` file

I'll look into some of the Regex performance stuff when I have more time, but this was quick and just some cleanup stuff