### PR TITLE
Implemented Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Syntax: `AddressExtractor.exe <input [[... input]]> [-o output] [-r report]`
 
 ### Performance / Debugging
 
-| Option           | Description                                                                                                                       |
-|------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| `--debug`        | Enable debug mode for fine-tuned performance checking                                                                             |
-| `--channels` num | Uses multiple [channels](https://learn.microsoft.com/en-us/dotnet/core/extensions/channels) for reading from files. Defaults to 4 |
+| Option          | Description                                                                                                                                      |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--debug`       | Enable debug mode for fine-tuned performance checking                                                                                            |
+| `--threads` num | Uses multiple threads with [channels](https://learn.microsoft.com/en-us/dotnet/core/extensions/channels) for reading from files. Defaults to `4` |

--- a/README.md
+++ b/README.md
@@ -29,13 +29,21 @@ Syntax: `AddressExtractor.exe -?`
 Syntax: `AddressExtractor.exe -v`
 Syntax: `AddressExtractor.exe <input [[... input]]> [-o output] [-r report]`
 
-| Option                  | Description                                                                |
-|-------------------------|----------------------------------------------------------------------------|
-| `-?`, `-h`, `--help`    | Prints the command line syntax and options                                 |
-| `-v`, `--version`       | Prints the application version number                                      |
-| input                   | One or more input filenames or directories                                 |
-| `-o`, `--output` output | Path and filename of the output file. Defaults to 'addresses_output.txt'   |
-| `-r`, `--report` report | Path and filename of the report file. Defaults to 'report.txt'             |
+### Main Options
+
+| Option                  | Description                                                               |
+|-------------------------|---------------------------------------------------------------------------|
+| `-?`, `-h`, `--help`    | Prints the command line syntax and options                                |
+| `-v`, `--version`       | Prints the application version number                                     |
+| input                   | One or more input filenames or directories                                |
+| `-o`, `--output` output | Path and filename of the output file. Defaults to 'addresses_output.txt'  |
+| `-r`, `--report` report | Path and filename of the report file. Defaults to 'report.txt'            |
 | `--recursive`           | Enable recursive mode for directories, which will search child directories |
-| `-y`, `--yes`           | Automatically confirm prompts to CONTINUE without asking                   |
-| `--debug`               | Enable debug mode for fine-tuned performance checking                     |
+| `-y`, `--yes`           | Automatically confirm prompts to CONTINUE without asking                  |
+
+### Performance / Debugging
+
+| Option           | Description                                                                                                                       |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `--debug`        | Enable debug mode for fine-tuned performance checking                                                                             |
+| `--channels` num | Uses multiple [channels](https://learn.microsoft.com/en-us/dotnet/core/extensions/channels) for reading from files. Defaults to 4 |

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -20,21 +20,7 @@ namespace MyAddressExtractor
             | RegexOptions.NonBacktracking //  guarantees linear-time processing in the length of the input.
             | RegexOptions.CultureInvariant // Allow culture invariant character matching
         )]
-        public static partial Regex EmailRegex_Simple();
-
-
-        /// <summary>
-        /// Email Regex pattern with full complex checks
-        /// </summary>
-        [GeneratedRegex(
-            @"(\\"")?""?'?[a-z0-9\.\-\*!#$%&'+/=?^_`{|}~""\\]+(?<!\.)@([a-z0-9\-_]+\.)+[a-z0-9]{2,}\b(\\"")?""?'?(?<!\s)",
-            RegexOptions.ExplicitCapture // Require naming captures; implies '(?:)' on groups. We don't make use of the groups
-            | RegexOptions.IgnoreCase // Match upper and lower casing
-            | RegexOptions.Compiled // Compile the nodes
-            | RegexOptions.Singleline // Singleline mode
-            | RegexOptions.CultureInvariant // Allow culture invariant character matching
-        )]
-        public static partial Regex EmailRegex_Full();
+        public static partial Regex LooseMatch();
 
         #region File Extraction
 
@@ -65,9 +51,8 @@ namespace MyAddressExtractor
             if (string.IsNullOrWhiteSpace(content))
                 yield break;
 
-            var matches =
-                AddressExtractor.EmailRegex_Simple().Matches(content)
-                .Where(x => EmailRegex_Full().IsMatch(x.Value));
+            var matches = AddressExtractor.LooseMatch()
+                .Matches(content);
 
             using (var debug = stack.CreateStack("Run regex"))
             {

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -45,7 +45,7 @@ namespace MyAddressExtractor
         public IAsyncEnumerable<string> ExtractAddressesAsync(string? content, CancellationToken cancellation = default)
             => this.ExtractAddressesAsync(IPerformanceStack.DEFAULT, content, cancellation);
 
-        private async IAsyncEnumerable<string> ExtractAddressesAsync(IPerformanceStack stack, string? content, [EnumeratorCancellation] CancellationToken cancellation = default)
+        public async IAsyncEnumerable<string> ExtractAddressesAsync(IPerformanceStack stack, string? content, [EnumeratorCancellation] CancellationToken cancellation = default)
         {
             // If line is NULL or any time of whitespace, don't waste computation time searching any empty string
             if (string.IsNullOrWhiteSpace(content))

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -41,7 +41,7 @@ namespace MyAddressExtractor {
             this.Stack = stack;
             this.Timer = new Timer(_ => this.Log(), null, iterate, iterate);
 
-            for (int i = 0; i < this.Config.Channels; i++)
+            for (int i = 0; i < this.Config.Threads; i++)
                 this.Tasks.Add(Task.Run(() => this.ReadAsync(CancellationToken.None)));
         }
 

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -1,25 +1,66 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
+using System.Threading.Channels;
+using MyAddressExtractor.Objects;
 using MyAddressExtractor.Objects.Performance;
 
 namespace MyAddressExtractor {
     public class AddressExtractorMonitor : IAsyncDisposable {
+        private readonly CommandLineProcessor Config;
+        private readonly Channel<Line> Channel;
+        private ChannelReader<Line> Reader => this.Channel.Reader;
+        private ChannelWriter<Line> Writer => this.Channel.Writer;
+        private IList<Task> Tasks = new List<Task>();
+
         private readonly AddressExtractor Extractor = new();
         private readonly IPerformanceStack Stack;
 
         protected readonly IDictionary<string, Count> Files = new ConcurrentDictionary<string, Count>();
-        protected readonly ISet<string> Addresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        protected int Lines { get; private set; }
+        protected readonly ConcurrentDictionary<string, byte> Addresses = new(StringComparer.OrdinalIgnoreCase);
+
+        // ReadLine count
+        protected int Lines => this.LineCounter;
+        private int LineCounter;
 
         protected readonly Stopwatch Stopwatch = Stopwatch.StartNew();
         private readonly Timer Timer;
 
-        public AddressExtractorMonitor(IPerformanceStack stack): this(stack, TimeSpan.FromMinutes(1)) {}
-        public AddressExtractorMonitor(IPerformanceStack stack, TimeSpan iterate)
-        {
+        public AddressExtractorMonitor(
+            CommandLineProcessor config,
+            IPerformanceStack stack
+        ): this(config, stack, TimeSpan.FromMinutes(1)) {}
+
+        public AddressExtractorMonitor(
+            CommandLineProcessor config,
+            IPerformanceStack stack,
+            TimeSpan iterate
+        ) {
+            this.Config = config;
+            this.Channel = this.Config.CreateChannel();
             this.Stack = stack;
             this.Timer = new Timer(_ => this.Log(), null, iterate, iterate);
+
+            for (int i = 0; i < this.Config.Channels; i++)
+                this.Tasks.Add(Task.Run(() => this.ReadAsync(CancellationToken.None)));
+        }
+
+        private async Task ReadAsync(CancellationToken cancellation)
+        {
+            try {
+                while (await this.Reader.ReadAsync(cancellation) is var line)
+                {
+                    await foreach(var email in this.Extractor.ExtractAddressesAsync(this.Stack, line.Value, cancellation))
+                    {
+                        if (this.Addresses.TryAdd(email, 0))
+                            line.Counter.Add();
+                        Interlocked.Increment(ref this.LineCounter);
+                    }
+                }
+            } catch (ChannelClosedException) {
+            } catch (Exception e) {
+                Console.WriteLine(e);
+            }
         }
 
         public async ValueTask RunAsync(string inputFilePath, CancellationToken cancellation = default)
@@ -27,18 +68,23 @@ namespace MyAddressExtractor {
             using (var stack = this.Stack.CreateStack("Read file"))
             {
                 var count = new Count();
-                var addresses = 0;
 
                 this.Files.Add(inputFilePath, count);
 
                 var parser = FileExtensionParsing.GetFromPath(inputFilePath);
                 await using (var reader = parser.GetReader(inputFilePath))
                 {
-                    await foreach(var email in this.Extractor.ExtractFileAddressesAsync(stack, reader, cancellation))
+                    await foreach(var line in reader.ReadLineAsync(cancellation))
                     {
-                        if (this.Addresses.Add(email))
-                            count.Value = addresses++;
-                        this.Lines++;
+                        stack.Step("Read line");
+                        if (line is not null)
+                        {
+                            await this.Writer.WriteAsync(new Line {
+                                File = inputFilePath,
+                                Value = line,
+                                Counter = count
+                            }, cancellation);
+                        }
                     }
                 }
             }
@@ -55,15 +101,22 @@ namespace MyAddressExtractor {
             this.Stack.Log();
         }
 
-        internal async ValueTask SaveAsync(CommandLineProcessor cli, CancellationToken cancellation = default)
+        internal async ValueTask AwaitCompletion()
         {
-            string output = cli.OutputFilePath;
-            string report = cli.ReportFilePath;
+            this.Writer.Complete();
+            await Task.WhenAll(this.Tasks);
+            await this.Reader.Completion;
+        }
+
+        internal async ValueTask SaveAsync(CancellationToken cancellation = default)
+        {
+            string output = this.Config.OutputFilePath;
+            string report = this.Config.ReportFilePath;
             if (!string.IsNullOrWhiteSpace(output))
             {
                 await File.WriteAllLinesAsync(
                     output,
-                    this.Addresses.Select(address => address.ToLowerInvariant())
+                    this.Addresses.Keys.Select(address => address.ToLowerInvariant())
                         .OrderBy(address => address, StringComparer.OrdinalIgnoreCase),
                     cancellation
                 );

--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -12,7 +12,7 @@ namespace MyAddressExtractor
         public bool OperateRecursively { get; private set; } = Defaults.OPERATE_RECURSIVELY;
         public bool SkipPrompts { get; private set; } = Defaults.SKIP_PROMPTS;
 
-        public int Channels { get; private set; } = Defaults.CHANNELS;
+        public int Threads { get; private set; } = Defaults.CHANNELS;
 
         public bool Debug { get; private set; } = Defaults.DEBUG;
 
@@ -84,8 +84,8 @@ namespace MyAddressExtractor
                                 case "-debug":
                                     this.Debug = true;
                                     break;
-                                case "-channels":
-                                    handle = value => this.Channels = this.ParseInt(value, min: 0, max: 1000);
+                                case "-threads":
+                                    handle = value => this.Threads = this.ParseInt(value, min: 1, max: 1000);
                                     break;
                                 default:
                                     throw new ArgumentException($"Unexpected option '{arg}'");
@@ -118,8 +118,9 @@ namespace MyAddressExtractor
         }
 
         public Channel<Line> CreateChannel()
-            => Channel.CreateBounded<Line>(new BoundedChannelOptions(this.Channels) {
+            => Channel.CreateBounded<Line>(new BoundedChannelOptions(this.Threads * 3) {
                 SingleWriter = true, // Only one instance of `ILineReader` is used at a time
+                SingleReader = false,
                 AllowSynchronousContinuations = false // Require Async
             });
 

--- a/src/Count.cs
+++ b/src/Count.cs
@@ -6,7 +6,11 @@ namespace MyAddressExtractor {
     /// </summary>
     public sealed class Count
     {
-        public int Value = 0;
+        public int Value => this._Value;
+        private int _Value = 0;
+
+        public void Add(int value = 1)
+            => Interlocked.Add(ref this._Value, value);
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Objects/Filters/StrictMatchFilter.cs
+++ b/src/Objects/Filters/StrictMatchFilter.cs
@@ -2,31 +2,27 @@ using System.Text.RegularExpressions;
 using MyAddressExtractor.Objects.Attributes;
 
 namespace MyAddressExtractor.Objects.Filters {
-    /// <summary>
-    /// A negative-regex pattern for filtering out bad emails
-    /// </summary>
-    [AddressFilter(Priority = 800)]
-    public sealed partial class InvalidAddressFilter : AddressFilter.BaseFilter {
+    [AddressFilter(Priority = 990)]
+    public sealed partial class StrictMatchFilter : AddressFilter.BaseFilter
+    {
         /// <summary>
-        /// \.\.	Email having consecutive dot
-        /// \*	    Email having *
-        /// .@	    Email having .@
-        /// @-	    Email having @-
+        /// Email Regex pattern with full complex checks
         /// </summary>
         [GeneratedRegex(
-            @"\.\.|\*|\.@|^\.|@-",
+            @"(\\"")?""?'?[a-z0-9\.\-\*!#$%&'+/=?^_`{|}~""\\]+(?<!\.)@([a-z0-9\-_]+\.)+[a-z0-9]{2,}\b(\\"")?""?'?(?<!\s)",
             RegexOptions.ExplicitCapture // Require naming captures; implies '(?:)' on groups. We don't make use of the groups
             | RegexOptions.IgnoreCase // Match upper and lower casing
             | RegexOptions.Compiled // Compile the nodes
             | RegexOptions.Singleline // Singleline mode
+            | RegexOptions.CultureInvariant // Allow culture invariant character matching
         )]
-        public static partial Regex InvalidEmailRegex();
+        public static partial Regex StrictRegex();
 
-        public override string Name => "Filter invalids";
+        public override string Name => "Strict Match";
 
         /// <inheritdoc />
         public override Result ValidateEmailAddress(ref EmailAddress address)
-            => this.Continue(!InvalidAddressFilter.InvalidEmailRegex()
+            => this.Continue(StrictMatchFilter.StrictRegex()
                 .IsMatch(address.Full));
     }
 }

--- a/src/Objects/Line.cs
+++ b/src/Objects/Line.cs
@@ -1,0 +1,17 @@
+namespace MyAddressExtractor.Objects
+{
+    /// <summary>
+    /// A line read from a file
+    /// </summary>
+    public struct Line
+    {
+        /// <summary>The file the line was read from</summary>
+        public string File { get; init; }
+
+        /// <summary>The value of the Line</summary>
+        public string Value { get; init; }
+
+        /// <summary>The reader count</summary>
+        public Count Counter { get; init; }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -61,7 +61,11 @@ namespace MyAddressExtractor
                             await monitor.RunAsync(file, CancellationToken.None);
 
                         } catch (Exception ex) {
-                            Console.Error.WriteLine($"An error occurred while reading '{file}': {ex.Message}");
+                            if (config.Debug)
+                                Console.WriteLine(new Exception($"An error occurred while reading '{file}':", ex));
+                            else
+                                Console.Error.WriteLine($"An error occurred while reading '{file}': {ex.Message}");
+
                             if (ex is not NotImplementedException && !config.WaitContinue())
                                 return (int)ErrorCode.UnspecifiedError;
                         }


### PR DESCRIPTION
This implements Channels for running through lines concurrently, it uses a single-writer (File reader) format with multiple readers (Running the lines through the Regex).

You can customize the Channel size with `--threads #`

By default it will use `4` tasks, which will result in roughly the following performance:

```
Extraction time: 59s
Addresses extracted: 9,451,035
Read lines total: 9,451,035
Read lines rate: 160,331/s

 - Run regex x10,000,001 | Took 2.9m (at ~17μs per)
   - Generate capture x10,000,000 | Took 35s (at ~3μs per)
   - Check length     x10,000,000 | Took 6s (at ~1μs per)
   - Strict Match     x10,000,000 | Took 21s (at ~2μs per)
   - Domain filter    x10,000,000 | Took 16s (at ~2μs per)
   - Filter invalids  x9,628,689 | Took 15s (at ~2μs per)
   - Filter quotes    x9,451,035 | Took 10s (at ~1μs per)
   - TLD Filter       x9,451,035 | Took 4s (at ~0μs per)
 - Read file x1 | Took 59s (at ~59s per)
   - Read line x10,000,001 | Took 58s (at ~6μs per)
```

```
Extraction time: 54s
Addresses extracted: 9,451,035
Read lines total: 9,451,035
Read lines rate: 175,389/s

 - Run regex x10,000,001 | Took 2.6m (at ~16μs per)
   - Generate capture x10,000,000 | Took 32s (at ~3μs per)
   - Check length     x10,000,000 | Took 6s (at ~1μs per)
   - Strict Match     x10,000,000 | Took 18s (at ~2μs per)
   - Domain filter    x10,000,000 | Took 16s (at ~2μs per)
   - Filter invalids  x9,628,689 | Took 14s (at ~1μs per)
   - Filter quotes    x9,451,035 | Took 8s (at ~1μs per)
   - TLD Filter       x9,451,035 | Took 3s (at ~0μs per)
 - Read file x1 | Took 54s (at ~54s per)
   - Read line x10,000,001 | Took 53s (at ~5μs per)
```

I tacked on a `0` to get `--threads 40`, and pushed 180k/s, but at some point there's diminishing return so I'm not sure the "optimal" channel size to use. YMMV using the `--threads` option.

----

I also cleaned up some stuff so when testing the 1.9gb test dump it wouldn't keep writing to disk afterwards, `-o` and `-r` can now accept `""` from the commandline and will not save when so. Previously `arg[0]` was used, so providing `string.Empty` would throw an out of bounds exception.

----

I cleaned up `DebugPerformanceStack` a bunch so that it'll properly handle accepting from multiple threads at the same time.

----

I also changed it so that `--debug` will print a full stacktrace when an exception occurs, so #54 should be easier to pinpoint.