### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ Syntax: `AddressExtractor.exe <input [[... input]]> [-o output] [-r report]`
 
 ### Main Options
 
-| Option                  | Description                                                               |
-|-------------------------|---------------------------------------------------------------------------|
-| `-?`, `-h`, `--help`    | Prints the command line syntax and options                                |
-| `-v`, `--version`       | Prints the application version number                                     |
-| input                   | One or more input filenames or directories                                |
-| `-o`, `--output` output | Path and filename of the output file. Defaults to 'addresses_output.txt'  |
-| `-r`, `--report` report | Path and filename of the report file. Defaults to 'report.txt'            |
+| Option                  | Description                                                                |
+|-------------------------|----------------------------------------------------------------------------|
+| `-?`, `-h`, `--help`    | Prints the command line syntax and options                                 |
+| `-v`, `--version`       | Prints the application version number                                      |
+| input                   | One or more input filenames or directories                                 |
+| `-o`, `--output` output | Path and filename of the output file. Defaults to 'addresses_output.txt'   |
+| `-r`, `--report` report | Path and filename of the report file. Defaults to 'report.txt'             |
 | `--recursive`           | Enable recursive mode for directories, which will search child directories |
-| `-y`, `--yes`           | Automatically confirm prompts to CONTINUE without asking                  |
+| `-y`, `--yes`           | Automatically confirm prompts to CONTINUE without asking                   |
+| `-q`, `--quiet`         | Run with less verbosity, progress messages aren't shown                    |
 
 ### Performance / Debugging
 

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -31,6 +31,8 @@ namespace MyAddressExtractor
         {
             await foreach (var line in reader.ReadLineAsync(cancellation))
             {
+                cancellation.ThrowIfCancellationRequested();
+
                 stack.Step("Read line");
                 await foreach (var address in this.ExtractAddressesAsync(stack, line, cancellation))
                 {
@@ -67,6 +69,8 @@ namespace MyAddressExtractor
                         // Run each filter
                         foreach (var filter in AddressFilter.Filters)
                         {
+                            cancellation.ThrowIfCancellationRequested();
+
                             valid = await filter.ValidateEmailAddressAsync(ref address, cancellation);
                             debug.Step(filter.Name);
 

--- a/src/AddressExtractor.csproj
+++ b/src/AddressExtractor.csproj
@@ -8,4 +8,8 @@
     <LangVersion>11</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.5.22" />
+  </ItemGroup>
+
 </Project>

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -42,48 +42,87 @@ namespace MyAddressExtractor {
             this.Timer = new Timer(_ => this.Log(), null, iterate, iterate);
 
             for (int i = 0; i < this.Config.Threads; i++)
-                this.Tasks.Add(Task.Run(() => this.ReadAsync(CancellationToken.None)));
+            {
+                var task = Task.Run(() => this.ReadAsync(config.CancellationToken));
+                this.Tasks.Add(task);
+            }
         }
 
         private async Task ReadAsync(CancellationToken cancellation)
         {
-            try {
-                while (await this.Reader.ReadAsync(cancellation) is var line)
+            while (!cancellation.IsCancellationRequested)
+            {
+                Line line = default;
+
+                try
                 {
-                    await foreach(var email in this.Extractor.ExtractAddressesAsync(this.Stack, line.Value, cancellation))
+                    // Tasks run forever
+                    while (!cancellation.IsCancellationRequested)
                     {
-                        if (this.Addresses.TryAdd(email, 0))
-                            line.Counter.Add();
-                        Interlocked.Increment(ref this.LineCounter);
+                        // Get a line from the Channel
+                        line = await this.Reader.ReadAsync(cancellation);
+
+                        // Check for pauses
+                        await this.Config.AwaitContinuationAsync(cancellation);
+
+                        // Extract addresses from the line
+                        await foreach(var email in this.Extractor.ExtractAddressesAsync(this.Stack, line.Value, cancellation))
+                        {
+                            if (this.Addresses.TryAdd(email, 0))
+                                line.Counter.Increment();
+                            Interlocked.Increment(ref this.LineCounter);
+
+                            // Disabled currently, alternating log messages has oddities
+                            /*if (!this.Config.Quiet && this.Lines % 25000 is 0)
+                                Output.Write($"Checked {this.Lines:n0} lines, found {line.Counter.Value:n0} emails");*/
+                        }
                     }
+                } catch (ChannelClosedException) {
+                    break; // Break the Task when Channel closed
+                } catch (TaskCanceledException) {
+                    break; // Break the Task when Tasks are cancelled
+                } catch (Exception ex) {
+                    if (this.Config.Debug)
+                        Output.Exception(new Exception($"An error occurred while parsing '{line.File}'L{line.Number}:", ex));
+                    else
+                        Output.Error($"An error occurred while parsing '{line.File}'L{line.Number}: {ex.Message}");
+
+                    if (!await this.Config.WaitOnExceptionAsync(cancellation))
+                        break;
                 }
-            } catch (ChannelClosedException) {
-            } catch (Exception e) {
-                Console.WriteLine(e);
             }
         }
 
-        public async ValueTask RunAsync(string inputFilePath, CancellationToken cancellation = default)
+        public async ValueTask RunAsync(FileInfo file, CancellationToken cancellation = default)
         {
             using (var stack = this.Stack.CreateStack("Read file"))
             {
+                var lines = 0;
                 var count = new Count();
 
-                this.Files.Add(inputFilePath, count);
+                this.Files.Add(file.FullName, count);
 
-                var parser = FileExtensionParsing.GetFromPath(inputFilePath);
-                await using (var reader = parser.GetReader(inputFilePath))
+                var parser = FileExtensionParsing.Get(file);
+                await using (var reader = parser.GetReader(file.FullName))
                 {
+                    // Await any 'continue' prompts
+                    await this.Config.AwaitContinuationAsync(cancellation);
+
+                    Output.Write($"Reading \"{file.FullName}\" [{ByteExtensions.Format(file.Length)}]");
                     await foreach(var line in reader.ReadLineAsync(cancellation))
                     {
                         stack.Step("Read line");
                         if (line is not null)
                         {
                             await this.Writer.WriteAsync(new Line {
-                                File = inputFilePath,
+                                File = file.FullName,
                                 Value = line,
-                                Counter = count
+                                Counter = count,
+                                Number = ++lines
                             }, cancellation);
+
+                            if (!this.Config.Quiet && lines % 25000 is 0)
+                                Output.Write($"Read {lines:n0} lines from \"{file.Name}\"");
                         }
                     }
                 }
@@ -92,16 +131,16 @@ namespace MyAddressExtractor {
 
         public virtual void Log()
         {
-            Console.WriteLine($"Extraction time: {this.Stopwatch.Format()}");
-            Console.WriteLine($"Addresses extracted: {this.Addresses.Count:n0}");
+            Output.Write($"Extraction time: {this.Stopwatch.Format()}");
+            Output.Write($"Addresses extracted: {this.Addresses.Count:n0}");
             long rate = (long)(this.Lines / (this.Stopwatch.ElapsedMilliseconds / 1000.0));
-            Console.WriteLine($"Read lines total: {this.Lines:n0}");
-            Console.WriteLine($"Read lines rate: {rate:n0}/s\n");
+            Output.Write($"Read lines total: {this.Lines:n0}");
+            Output.Write($"Read lines rate: {rate:n0}/s\n");
 
             this.Stack.Log();
         }
 
-        internal async ValueTask AwaitCompletion()
+        internal async ValueTask AwaitCompletionAsync()
         {
             this.Writer.Complete();
             await Task.WhenAll(this.Tasks);

--- a/src/Count.cs
+++ b/src/Count.cs
@@ -9,8 +9,8 @@ namespace MyAddressExtractor {
         public int Value => this._Value;
         private int _Value = 0;
 
-        public void Add(int value = 1)
-            => Interlocked.Add(ref this._Value, value);
+        public void Increment()
+            => Interlocked.Increment(ref this._Value);
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -34,5 +34,27 @@ namespace MyAddressExtractor {
             TimeUnit.DAYS => span.TotalDays,
             _ => throw new ArgumentOutOfRangeException(nameof(unit), unit, null)
         };
+
+        /// <summary>
+        /// A safe call to <see cref="string.StartsWith(string)"/> and <see cref="string.EndsWith(string)"/>
+        /// Guarantees that the string is actually long enough for the start and end to be different
+        /// (eg; `"abc".StartsAndEndsWith("abc")` will be FALSE, and `"abcabc".StartsAndEndsWith("abc" will be TRUE)`)
+        /// </summary>
+        public static bool StartsAndEndsWith(this string check, string value)
+            => check.Length >= value.Length * 2 && check.StartsWith(value) && check.EndsWith(value);
+
+        /// <summary>
+        /// A safe call to <see cref="string.StartsWith(char)"/> and <see cref="string.EndsWith(char)"/>
+        /// Guarantees that the string is actually long enough for the start and end to be different
+        /// (eg; `"abc".StartsAndEndsWith("abc")` will be FALSE, and `"abcabc".StartsAndEndsWith("abc" will be TRUE)`)
+        /// </summary>
+        public static bool StartsAndEndsWith(this string check, char value)
+            => check.Length >= 2 && check.StartsWith(value) && check.EndsWith(value);
+
+        /// <summary>
+        /// Just here for testing
+        /// </summary>
+        public static bool NextBool(this Random random)
+            => random.NextDouble() >= 0.5d;
     }
 }

--- a/src/Objects/EmailAddress.cs
+++ b/src/Objects/EmailAddress.cs
@@ -58,7 +58,6 @@ namespace MyAddressExtractor.Objects {
                 this._Full = $"{username}@{this._Domain}";
 
                 // Clear the cache
-                this._Separator = null;
                 this._Username = null;
 
                 this.Modified = true;

--- a/src/Objects/Filters/QuotesFilter.cs
+++ b/src/Objects/Filters/QuotesFilter.cs
@@ -15,20 +15,20 @@ namespace MyAddressExtractor.Objects.Filters {
             var username = address.Username;
 
             // Handle quotes at the start and end of the username
-            if (username.StartsWith('\'') && username.EndsWith('\''))
+            if (username.StartsAndEndsWith('\''))
                 username = username[1..^1];
-            if (username.StartsWith('"') && username.EndsWith('"'))
+            if (username.StartsAndEndsWith('"'))
                 username = username[1..^1];
-            if (username.StartsWith("\\\"") && username.EndsWith("\\\""))
+            if (username.StartsAndEndsWith("\\\""))
                 username = username[2..^2];
 
             // Does the username contain any unescaped double quotes?
             var quoteIndex = username.IndexOf('"');
             var unescapedQuoteCount = 0;
 
-            while (quoteIndex != -1)
+            while (quoteIndex is not -1)
             {
-                if (quoteIndex == 0 || (quoteIndex > 0 && username[quoteIndex - 1] != '\\'))
+                if (quoteIndex is 0 || (quoteIndex > 0 && username[quoteIndex - 1] != '\\'))
                 {
                     unescapedQuoteCount++;
                 }
@@ -50,12 +50,12 @@ namespace MyAddressExtractor.Objects.Filters {
                     len = null;
                     if (junk is string str)
                     {
-                        if (address.Full.StartsWith(str) && address.Full.EndsWith(str))
+                        if (address.Full.StartsAndEndsWith(str))
                             len = str.Length;
                     }
                     else if (junk is char c)
                     {
-                        if (address.Full.StartsWith(c) && address.Full.EndsWith(c))
+                        if (address.Full.StartsAndEndsWith(c))
                             len = 1;
                     }
 

--- a/src/Objects/Line.cs
+++ b/src/Objects/Line.cs
@@ -6,12 +6,15 @@ namespace MyAddressExtractor.Objects
     public struct Line
     {
         /// <summary>The file the line was read from</summary>
-        public string File { get; init; }
+        public required string File { get; init; }
 
         /// <summary>The value of the Line</summary>
-        public string Value { get; init; }
+        public required string Value { get; init; }
 
-        /// <summary>The reader count</summary>
-        public Count Counter { get; init; }
+        /// <summary>The count of extracted Email Addresses</summary>
+        public required Count Counter { get; init; }
+
+        /// <summary>The current line number</summary>
+        public required int Number { get; init; }
     }
 }

--- a/src/Objects/Output.cs
+++ b/src/Objects/Output.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+
+namespace MyAddressExtractor.Objects
+{
+    public static class Output
+    {
+        public static void Write(string line)
+            => Output.Write(Console.Out, line);
+
+        public static void Exception(Exception ex, bool trace = true)
+            => Output.Write(Console.Error, trace ? ex : ex.Message);
+
+        public static void Error(string line)
+            => Output.Write(Console.Error, line);
+
+        private static void Write(TextWriter to, object? e)
+        {
+            if (e is null)
+                return;
+            to.WriteLine($"[{Output.DateTime()}] {e}");
+        }
+
+        private static string DateTime()
+            => System.DateTime.Now.ToString(CultureInfo.CurrentCulture);
+    }
+}

--- a/src/Objects/UserPromptLock.cs
+++ b/src/Objects/UserPromptLock.cs
@@ -1,0 +1,70 @@
+using Microsoft.VisualStudio.Threading;
+
+namespace MyAddressExtractor.Objects {
+    internal sealed class UserPromptLock {
+        /// <summary>A Semaphore with a single handle, so multiple Tasks cannot prompt</summary>
+        private readonly SemaphoreSlim Semaphore = new(1);
+
+        private readonly AsyncManualResetEvent Holder = new(/* True by default to allow reading */ initialState: true);
+
+        private readonly CancellationTokenSource Source;
+
+        public UserPromptLock(CancellationTokenSource source)
+        {
+            this.Source = source;
+        }
+
+        internal async ValueTask<bool> PromptAsync(CancellationToken cancellation = default)
+        {
+            // Wait to enter the semaphore
+            await this.Semaphore.WaitAsync(cancellation);
+            try {
+                // If cancelled already, exit
+                if (this.Source.IsCancellationRequested)
+                    return false;
+
+                // Reset allowed-continue to false
+                this.Holder.Reset();
+                try {
+                    Console.Write("Continue? [y/n]: ");
+
+                    // Wait for a Y/N keypress and ignore any others
+                    while (true)
+                    {
+                        var read = Console.ReadKey(intercept: true);
+
+                        // No modifiers (shift/ctrl/alt)
+                        if (read.Modifiers is 0)
+                        {
+                            switch (read.Key)
+                            {
+                                // Allow continuing
+                                case ConsoleKey.Y:
+                                    return true;
+
+                                // Exit
+                                case ConsoleKey.N:
+                                case ConsoleKey.Escape:
+                                    this.Source.Cancel();
+                                    return false;
+                            }
+                        }
+                    }
+
+                } finally {
+                    Console.WriteLine();
+
+                    // Set allowed-continue to true (Only if not exiting)
+                    if (!this.Source.IsCancellationRequested)
+                        this.Holder.Set();
+                }
+            } finally {
+                // Release the semaphore lock
+                this.Semaphore.Release();
+            }
+        }
+
+        public Task WaitAsync(CancellationToken cancellation = default)
+            => this.Holder.WaitAsync(cancellation);
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using MyAddressExtractor.Objects;
 using MyAddressExtractor.Objects.Performance;
 
 [assembly:InternalsVisibleTo("AddressExtractorTest")]
@@ -30,7 +31,7 @@ namespace MyAddressExtractor
             }
             catch (ArgumentException ae)
             {
-                Console.Error.WriteLine(ae.Message);
+                Output.Exception(ae, trace: false);
                 return (int)ErrorCode.InvalidArguments;
             }
             // If no input paths were listed, the usage was printed, so we should exit cleanly
@@ -45,7 +46,7 @@ namespace MyAddressExtractor
 
                 if (!config.WaitInput(files))
                     return (int)ErrorCode.NoError;
-                Console.WriteLine("Extracting...");
+                Output.Write("Extracting...");
 
                 IPerformanceStack perf = config.Debug
                     ? new DebugPerformanceStack() : IPerformanceStack.DEFAULT;
@@ -58,45 +59,54 @@ namespace MyAddressExtractor
                     foreach (var file in files)
                     {
                         try {
-                            await monitor.RunAsync(file, CancellationToken.None);
-
+                            await monitor.RunAsync(file, config.CancellationToken);
+                        } catch (OperationCanceledException) {
+                            throw;
                         } catch (Exception ex) {
                             if (config.Debug)
-                                Console.WriteLine(new Exception($"An error occurred while reading '{file}':", ex));
+                                Output.Exception(new Exception($"An error occurred while reading '{file}':", ex));
                             else
-                                Console.Error.WriteLine($"An error occurred while reading '{file}': {ex.Message}");
+                                Output.Error($"An error occurred while reading '{file}': {ex.Message}");
 
-                            if (ex is not NotImplementedException && !config.WaitContinue())
+                            if (ex is not NotImplementedException && !await config.WaitOnExceptionAsync(config.CancellationToken))
                                 return (int)ErrorCode.UnspecifiedError;
                         }
                     }
 
                     // Wait for completion
-                    Console.WriteLine("Finished reading files");
-                    await monitor.AwaitCompletion();
+                    Output.Write("Finished reading files");
+                    await monitor.AwaitCompletionAsync();
 
                     // Log one last time out of the Timer loop
                     monitor.Log();
 
                     if (saveOutput || saveReport)
                     {
-                        Console.WriteLine("Saving to disk..");
+                        Output.Write("Saving to disk..");
                         await monitor.SaveAsync(CancellationToken.None);
                     }
                 }
 
                 if (saveOutput)
-                    Console.WriteLine($"Addresses saved to {config.OutputFilePath}");
+                    Output.Write($"Addresses saved to {config.OutputFilePath}");
 
                 if (saveReport)
-                    Console.WriteLine($"Report saved to {config.ReportFilePath}");
+                    Output.Write($"Report saved to {config.ReportFilePath}");
+            }
+            catch (TaskCanceledException)
+            {
+                return (int)ErrorCode.UnspecifiedError;
+            }
+            catch (OperationCanceledException)
+            {
+                return (int)ErrorCode.UnspecifiedError;
             }
             catch (Exception ex)
             {
                 if (config.Debug)
-                    Console.WriteLine(ex);
+                    Output.Exception(ex);
                 else
-                    Console.Error.WriteLine($"An error occurred: {ex.Message}");
+                    Output.Error($"An error occurred: {ex.Message}");
                 return (int)ErrorCode.UnspecifiedError;
             }
 

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -193,6 +193,16 @@ namespace AddressExtractorTest
         }
 
         [TestMethod]
+        [Ignore("The loose address matching captures this as a valid address, TBD if it should be valid or not")]
+        public async Task WeirdAddressTesting()
+        {
+            const string INPUT = "'@nicedomain.com";
+
+            // OK if this doesn't throw any exceptions!
+            var result = await this.ExtractAddressesAsync(INPUT);
+        }
+
+        [TestMethod]
         [Ignore("This is a low priority feature so the test is ignored for the moment in the interests of having all green all the way for tests that *should* be working now")]
         public async Task AliasOnEmojiDomainIsFound()
         {


### PR DESCRIPTION
Added some missing information to the `--help` flag that was present in the `README.md` but not the program help

----

Fixed #54 

Fixed "Length cannot be less than 0" Exception that was being thrown. `QuotesFilter` checks for matching opening and closed quotes on the Username part of the address and then trims  The current loose Regex considers `'@domain.com` a validate match, and then the filter checks if `'` StartsWith `'` and EndsWith `'`, which is `true`, but then trimming from `1` to `0` equals `-1`, which is an invalid trim. Thus the exception.

----

Fixed #58

Added an output message whenever a new file is opened that the file is being read

```csharp
Output.Write($"Reading \"{file.FullName}\" [{ByteExtensions.Format(file.Length)}]");
```

The amount of lines that have been read from a file is now logged to indicate progress. I tested with `1000` or `10000` lines but currently have it set at every `25000`  lines, since the read can be fairly fast.

```csharp
if (lines % 25000 is 0)
    Output.Write($"Read {lines:n0} lines from \"{file.Name}\"");
```

If the new `-q` or `--quiet` flag is used then this message won't be written.

----

Created an `Output` class with some methods that replace the use of `Console.WriteLine` calls, using some of the formatting provided in #58 the current DateTime is now prefixed on messages:

```csharp
private static string DateTime()
    => System.DateTime.Now.ToString(CultureInfo.CurrentCulture);
```

----

"Fixed?" #59 

Any Exception occurring inside of any long-running `Task` will now halt all other `Task`s and prompt with a `Continue [y/n]?` unless the `--yes` flag is present. If *no* then a `TaskCancelledException` is thrown on all waiting Tasks, and the program is stopped.