### PR TITLE
Configuration Changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,9 @@ public sealed class MyFileReader : ILineReader
     private readonly string File;
 
     // A new instance of the reader is constructed for every file.
-    // This allows us to store local variables if need be while reading through the file
-    // We should accept the path here in the constructor, which we'll make use of later
+    //   This allows us to store local variables if need be while reading through the file
+    //   We should accept the path here in the constructor, which we'll make use of later
+    // Reflection will provide a Constructor with a 'string', 'Runtime', or 'Config'
     public MyFileReader(string file)
     {
         // The file when passed into the constructor is a valid system file

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Syntax: `AddressExtractor.exe <input [[... input]]> [-o output] [-r report]`
 
 ### Performance / Debugging
 
-| Option          | Description                                                                                                                                      |
-|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--debug`       | Enable debug mode for fine-tuned performance checking                                                                                            |
-| `--threads` num | Uses multiple threads with [channels](https://learn.microsoft.com/en-us/dotnet/core/extensions/channels) for reading from files. Defaults to `4` |
+| Option              | Description                                                                                                                                      |
+|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--debug`           | Enable debug mode for fine-tuned performance checking                                                                                            |
+| `--threads` num     | Uses multiple threads with [channels](https://learn.microsoft.com/en-us/dotnet/core/extensions/channels) for reading from files. Defaults to `4` |
+| `--skip-exceptions` | Automatically prompts on CONTINUE when an exception occurs                                                                                       |

--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -22,6 +22,13 @@ namespace MyAddressExtractor
         )]
         public static partial Regex LooseMatch();
 
+        private readonly Runtime Runtime;
+        
+        public AddressExtractor(Runtime runtime)
+        {
+            this.Runtime = runtime;
+        }
+
         #region File Extraction
 
         public IAsyncEnumerable<string> ExtractFileAddressesAsync(ILineReader reader, CancellationToken cancellation = default)
@@ -67,7 +74,7 @@ namespace MyAddressExtractor
                     while (true)
                     {
                         // Run each filter
-                        foreach (var filter in AddressFilter.Filters)
+                        foreach (var filter in this.Runtime.Filters)
                         {
                             cancellation.ThrowIfCancellationRequested();
 

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -7,7 +7,7 @@ using MyAddressExtractor.Objects.Performance;
 
 namespace MyAddressExtractor {
     public class AddressExtractorMonitor : IAsyncDisposable {
-        private readonly CommandLineProcessor Config;
+        private readonly Config Config;
         private readonly Channel<Line> Channel;
         private ChannelReader<Line> Reader => this.Channel.Reader;
         private ChannelWriter<Line> Writer => this.Channel.Writer;
@@ -27,12 +27,12 @@ namespace MyAddressExtractor {
         private readonly Timer Timer;
 
         public AddressExtractorMonitor(
-            CommandLineProcessor config,
+            Config config,
             IPerformanceStack stack
         ): this(config, stack, TimeSpan.FromMinutes(1)) {}
 
         public AddressExtractorMonitor(
-            CommandLineProcessor config,
+            Config config,
             IPerformanceStack stack,
             TimeSpan iterate
         ) {

--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -1,42 +1,16 @@
-﻿using System.Reflection;
-using System.Threading.Channels;
-using MyAddressExtractor.Objects;
+﻿using MyAddressExtractor.Objects;
 
 namespace MyAddressExtractor
 {
     public class CommandLineProcessor
     {
-        #region Config Options
-
-        public string OutputFilePath { get; private set; } = Defaults.OUTPUT_FILE_PATH;
-        public string ReportFilePath { get; private set; } = Defaults.REPORT_FILE_PATH;
-
-        public bool OperateRecursively { get; private set; } = Defaults.OPERATE_RECURSIVELY;
-        public bool SkipPrompts { get; private set; } = Defaults.SKIP_PROMPTS;
-
-        public int Threads { get; private set; } = Defaults.CHANNELS;
-
-        public bool Debug { get; private set; } = Defaults.DEBUG;
-        public bool Quiet { get; private set; } = Defaults.QUIET;
-
-        #endregion
-        #region Runtime
-
-        private readonly UserPromptLock PromptLock;
-        private readonly CancellationTokenSource ProgramCancellation;
-        public CancellationToken CancellationToken => this.ProgramCancellation.Token;
-
-        #endregion
-
-        internal CommandLineProcessor(IReadOnlyCollection<string> args, out IList<string> inputFilePaths)
+        internal static Config Parse(IReadOnlyCollection<string> args, out IList<string> inputFilePaths)
         {
-            this.ProgramCancellation = new CancellationTokenSource();
-            this.PromptLock = new UserPromptLock(this.ProgramCancellation);
-
             if (args.Count == 0)
                 throw new ArgumentException("Please provide at least one input file path.");
 
-            Action<string>? handle = null;
+            Config config = new();
+            Config.Writer? handle = null;
             string previous = string.Empty;
 
             inputFilePaths = new List<string>();
@@ -63,53 +37,9 @@ namespace MyAddressExtractor
                     if (arg[0] == '-')
                     {
                         if (arg.Length > 1)
-                        {
-                            var option = arg[1..];
-                            switch (option)
-                            {
-                                case "-recursive":
-                                    this.OperateRecursively = true;
-                                    break;
-                                case "o" or "-output":
-                                    handle = value => this.OutputFilePath = value;
-                                    break;
-                                case "r" or "-report":
-                                    handle = value => this.ReportFilePath = value;
-                                    break;
-                                case "y" or "-yes":
-                                    this.SkipPrompts = true;
-                                    break;
-                                case "v" or "-version":
-                                    if (args.Count > 1)
-                                    {
-                                        throw new ArgumentException($"'{arg}' must be the only argument when it is used");
-                                    }
-                                    Version();
-                                    return;
-                                case "?" or "h" or "-help":
-                                    if (args.Count > 1)
-                                    {
-                                        throw new ArgumentException($"'{arg}' must be the only argument when it is used");
-                                    }
-                                    Usage();
-                                    return;
-                                case "-debug":
-                                    this.Debug = true;
-                                    break;
-                                case "q" or "-quiet":
-                                    this.Quiet = true;
-                                    break;
-                                case "-threads":
-                                    handle = value => this.Threads = this.ParseInt(value, min: 1, max: 1000);
-                                    break;
-                                default:
-                                    throw new ArgumentException($"Unexpected option '{arg}'");
-                            }
-                        }
+                            handle = config.Set(args, arg);
                         else
-                        {
                             throw new ArgumentException($"Invalid argument '{arg}'");
-                        }
                     }
                     else // No option or not expecting an option file path, so assume it to be an input file path
                     {
@@ -127,121 +57,8 @@ namespace MyAddressExtractor
             // Make sure we have at least one input file path
             if (inputFilePaths.Count == 0)
                 throw new ArgumentException("No input file paths specified");
-        }
 
-        public Channel<Line> CreateChannel()
-            => Channel.CreateBounded<Line>(new BoundedChannelOptions(this.Threads * 3) {
-                SingleWriter = true, // Only one instance of `ILineReader` is used at a time
-                SingleReader = false,
-                AllowSynchronousContinuations = false // Require Async
-            });
-
-        #region Parsers
-
-        private int ParseInt(string value, int? min = null, int? max = null)
-        {
-            if (!int.TryParse(value, out int i))
-                throw new ArgumentException("Value must be a number");
-
-            if (i < min)
-                throw new ArgumentException($"Value cannot be less than {min}");
-
-            if (i > max)
-                throw new ArgumentException($"Value cannot be more than {max}");
-
-            return i;
-        }
-
-        #endregion
-        #region CLI Waiters
-
-        internal bool WaitInput(FileCollection files)
-        {
-            // If silent output don't prompt
-            if (this.SkipPrompts)
-                return true;
-
-            while (true)
-            {
-                Console.Write("Press ANY KEY to continue ['Q' to Quit; 'I' for info]: ");
-                var read = Console.ReadKey(intercept: true);
-                Console.WriteLine();
-
-                // No modifiers (shift/ctrl/alt)
-                if (read.Modifiers is 0)
-                {
-                    switch (read.Key)
-                    {
-                        case ConsoleKey.Q:
-                            Output.Write("Exiting");
-                            return false;
-                        case ConsoleKey.I:
-                            Output.Write($"Reading the following {files.Count} files:");
-                            foreach (var file in files)
-                            {
-                                Output.Write($"  [{ByteExtensions.Format(file.Length).PadRight(10)}] {file.FullName}");
-                            }
-                            Console.WriteLine();
-                            continue;
-                        default:
-                            return true;
-                    }
-                }
-            }
-        }
-
-        internal async ValueTask<bool> WaitOnExceptionAsync(CancellationToken cancellation = default)
-            => this.SkipPrompts // If silent output don't prompt
-            || await this.PromptLock.PromptAsync(cancellation);
-
-        internal Task AwaitContinuationAsync(CancellationToken cancellation = default)
-            => this.PromptLock.WaitAsync(cancellation);
-
-        #endregion
-        #region Special Output
-
-        static void Usage()
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            Console.WriteLine($"""
-                Syntax: {assembly.GetName().Name} -?
-                Syntax: {assembly.GetName().Name} -v
-                Syntax: {assembly.GetName().Name} <input [input...]> [-o output] [-r report]
-                
-                --help, -h, -?       Help for the command line arguments
-                -v                   Prints the application version
-                
-                input                One or more input file paths
-                -o output            File path to write output file
-                -r report            File path to write report file
-                
-                --debug              Enables debug mode, prints timings and exceptions
-                --threads #          Specifies the number of Tasks to use for parsing Regex
-                --recursive          Recursively enters directories provided to search for files
-                --yes, -y            Skips any prompts asking to continue
-                --quiet, -q          Runs in quiet mode, not as verbose
-            """);
-        }
-
-        static void Version()
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            Console.WriteLine(assembly.GetName().Version);
-        }
-
-        #endregion
-
-        public static class Defaults {
-            public const string OUTPUT_FILE_PATH = "addresses_output.txt";
-            public const string REPORT_FILE_PATH = "report.txt";
-
-            public const bool OPERATE_RECURSIVELY = false;
-            public const bool SKIP_PROMPTS = false;
-
-            public const int CHANNELS = 4;
-
-            public const bool DEBUG = false;
-            public const bool QUIET = false;
+            return config;
         }
     }
 }

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -5,14 +5,14 @@ using MyAddressExtractor.Objects;
 namespace MyAddressExtractor {
     internal sealed class FileCollection : IEnumerable<FileInfo>
     {
-        private readonly CommandLineProcessor Cli;
+        private readonly Config Config;
         private readonly IDictionary<string, FileInfo> Files;
 
         public int Count => this.Files.Count;
 
-        public FileCollection(CommandLineProcessor cli, IEnumerable<string> inputs)
+        public FileCollection(Config config, IEnumerable<string> inputs)
         {
-            this.Cli = cli;
+            this.Config = config;
             this.Files = this.CreateSystemSet();
             foreach (var file in this.GatherFiles(inputs))
                 this.Files[file.FullName] = file;
@@ -25,7 +25,7 @@ namespace MyAddressExtractor {
                 FileAttributes attributes = File.GetAttributes(file);
                 if (attributes.HasFlag(FileAttributes.Directory))
                 {
-                    if (!recursed || this.Cli.OperateRecursively)
+                    if (!recursed || this.Config.OperateRecursively)
                     {
                         foreach (var enumerated in this.GatherFiles(Directory.EnumerateFileSystemEntries(file), recursed: true))
                         {

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -5,14 +5,15 @@ using MyAddressExtractor.Objects;
 namespace MyAddressExtractor {
     internal sealed class FileCollection : IEnumerable<FileInfo>
     {
-        private readonly Config Config;
+        private readonly Runtime Runtime;
+        private Config Config => this.Runtime.Config;
         private readonly IDictionary<string, FileInfo> Files;
 
         public int Count => this.Files.Count;
 
-        public FileCollection(Config config, IEnumerable<string> inputs)
+        public FileCollection(Runtime runtime, IEnumerable<string> inputs)
         {
-            this.Config = config;
+            this.Runtime = runtime;
             this.Files = this.CreateSystemSet();
             foreach (var file in this.GatherFiles(inputs))
                 this.Files[file.FullName] = file;
@@ -64,7 +65,7 @@ namespace MyAddressExtractor {
             {
                 if (file.Extension is {Length: >0} extension)
                 {
-                    var info = infos.GetOrAdd(extension, _ => new ExtensionInfo(extension.ToLower()));
+                    var info = infos.GetOrAdd(extension, _ => new ExtensionInfo(this.Runtime, extension.ToLower()));
                     info.AddFile(file);
 
                     // Remove ignored files
@@ -102,10 +103,10 @@ namespace MyAddressExtractor {
             public int Count { get; private set; }
             public long Bytes { get; private set; }
 
-            public ExtensionInfo(string extension)
+            public ExtensionInfo(Runtime runtime, string extension)
             {
                 this.Extension = extension;
-                this.Parsing = FileExtensionParsing.Get(extension);
+                this.Parsing = runtime.GetExtension(extension);
             }
 
             public void AddFile(FileInfo info)

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -80,6 +80,11 @@ namespace MyAddressExtractor {
             {
                 Output.Write($"  {info.Extension.PadRight(6)} {info.Count:n0} files: {ByteExtensions.Format(info.Bytes)}{(info.Parsing.Read ? string.Empty : $", Skipping ({info.Parsing.Error})")}");
             }
+
+            string output = this.Config.OutputFilePath;
+            string report = this.Config.ReportFilePath;
+            Output.Write($"Output will {(string.IsNullOrWhiteSpace(output) ? "not be saved" : $"be saved to \"{output}\"")}.");
+            Output.Write($"Report will {(string.IsNullOrWhiteSpace(report) ? "not be saved" : $"be saved to \"{report}\"")}.");
         }
 
         /// <inheritdoc />

--- a/src/FileExtensionParsing.cs
+++ b/src/FileExtensionParsing.cs
@@ -1,95 +1,19 @@
-using System.Collections.Concurrent;
 using System.Reflection;
-using MyAddressExtractor.Objects.Attributes;
 using MyAddressExtractor.Objects.Readers;
 
 namespace MyAddressExtractor {
     internal sealed class FileExtensionParsing
     {
-        private static readonly IReadOnlyDictionary<string, FileExtensionParsing> FILE_EXTENSIONS;
-        private static readonly FileExtensionParsing UNKNOWN = new() { Error = "Unknown Extension" };
-        static FileExtensionParsing() {
-            var extensions = new ConcurrentDictionary<string, FileExtensionParsing>(StringComparer.OrdinalIgnoreCase);
-
-            // Archives
-            extensions.AddAll(
-                new[] { ".tar", ".gz", ".zip", ".rar", ".7z" },
-                new FileExtensionParsing { Error = "Archive files" }
-            );
-
-            // Images
-            extensions.AddAll(
-                new[] { ".png", ".tif", ".jpg", ".jpeg", ".gif", ".bmp", ".ai", ".psd", ".svg", ".ico" },
-                new FileExtensionParsing { Error = "Image files" }
-            );
-
-            // AudioVideo
-            extensions.AddAll(
-                new[] { ".rec", ".mp3", ".wav", ".mp4", ".mpg", ".mov", ".wmv", ".avi", ".m4v" },
-                new FileExtensionParsing { Error = "Audio/Video files" }
-            );
-
-            // Sql
-            extensions.AddAll(
-                new[] { ".frm", ".ibd", ".myi", ".myd" },
-                new FileExtensionParsing { Error = "Sql files" }
-            );
-
-            // Code
-            extensions.AddAll(
-                new[] { ".go", ".py", ".js", ".yml", ".php", ".c", ".sh", ".css", ".less", ".npmignore", ".groovy", ".scala", ".sass", ".ascx", ".markdown", ".bash", ".sln", ".h", ".ts", ".cs", ".aspx", ".csproj", ".nupk", ".suo", ".asax", ".resx", ".refesh", ".ipch" },
-                new FileExtensionParsing { Error = "Code files" }
-            );
-
-            // Source Control
-            extensions.AddAll(
-                new[] { ".svn-base", ".gitignore", ".gitattributes", ".pack" },
-                new FileExtensionParsing { Error = "Source-control files" }
-            );
-
-            // Executables
-            extensions.AddAll(
-                new[] { ".exe", ".dll", ".apk", ".jar", ".java",  "bin" },
-                new FileExtensionParsing { Error = "Executables" }
-            );
-
-            // Other
-            extensions.AddAll(
-                new[] { ".msi", ".flv", ".swf", ".pdb", ".brd", ".hprof", ".lock", ".docker", ".ttf", ".woff", ".woff2", ".pem", ".crt" },
-                new FileExtensionParsing { Error = "Unsupported" }
-            );
-
-            // A set of all extensions that should be eventually supported
-            // These are overriden using Reflection and do not need to be removed
-            extensions.AddAll(
-                new[] { ".log", ".json", ".txt", ".sql", ".xml", ".sample", ".csv", ".tsv", ".odt", ".docx", ".pptx", ".xls", ".doc", ".ppt", ".pdf", ".rdb" },
-                new FileExtensionParsing { Error = "Not currently supported" }
-            );
-
-            var types = Assembly.GetExecutingAssembly()
-                .GetTypes()
-                .Where(type => type.IsClass && !type.IsAbstract && type.IsAssignableTo(typeof(ILineReader)));
-            foreach (var type in types)
-            {
-                if (type.GetCustomAttribute<ExtensionTypesAttribute>() is {} attribute)
-                {
-                    var parsing = new FileExtensionParsing {
-                        Reader = FileExtensionParsing.CreateInstance(type)
-                    };
-
-                    // Use the setter to override any other instances
-                    foreach (string extension in attribute.Extensions)
-                        extensions[extension] = parsing;
-                }
-            }
-
-            FileExtensionParsing.FILE_EXTENSIONS = extensions;
-        }
-
         public bool Read => this.Error is null;
         public string? Error { get; init; } = null;
 
         private ReaderDelegate? Reader { get; init; } = null;
+
+        public FileExtensionParsing() {}
+        public FileExtensionParsing(Type type)
+        {
+            this.Reader = FileExtensionParsing.CreateInstance(type);
+        }
 
         public ILineReader GetReader(string path)
         {
@@ -99,15 +23,6 @@ namespace MyAddressExtractor {
         }
 
         #region Static Accessors
-
-        public static FileExtensionParsing Get(string extension)
-            => FileExtensionParsing.FILE_EXTENSIONS.GetValueOrDefault(extension, FileExtensionParsing.UNKNOWN);
-
-        public static FileExtensionParsing Get(FileInfo info)
-            => FileExtensionParsing.FILE_EXTENSIONS.GetValueOrDefault(info.Extension, FileExtensionParsing.UNKNOWN);
-
-        public static FileExtensionParsing GetFromPath(string path)
-            => FileExtensionParsing.FILE_EXTENSIONS.GetValueOrDefault(Path.GetExtension(path), FileExtensionParsing.UNKNOWN);
 
         private static ReaderDelegate CreateInstance(Type type)
         {

--- a/src/Objects/AddressFilter.cs
+++ b/src/Objects/AddressFilter.cs
@@ -1,26 +1,7 @@
-using System.Collections;
-using System.Reflection;
 using MyAddressExtractor.Objects.Attributes;
 
 namespace MyAddressExtractor.Objects {
     public sealed class AddressFilter {
-        public static readonly IEnumerable<BaseFilter> Filters;
-        static AddressFilter()
-        {
-            var filters = new FilterCollection();
-            var types = Assembly.GetExecutingAssembly()
-                .GetTypes()
-                .Where(type => type.IsClass && !type.IsAbstract && type.IsAssignableTo(typeof(BaseFilter)))
-                .OrderByDescending(type => type.GetCustomAttribute<AddressFilterAttribute>()?.Priority ?? -1);
-            foreach (Type type in types)
-            {
-                if (Activator.CreateInstance(type) is BaseFilter filter)
-                    filters.Add(filter);
-            }
-
-            AddressFilter.Filters = filters;
-        }
-
         /// <summary>
         /// A base class for checking whether an Email Address should be filtered out
         /// Instances of <see cref="BaseFilter"/> are created automatically using Reflection when the program starts
@@ -40,23 +21,6 @@ namespace MyAddressExtractor.Objects {
             /// <summary>Convert a <see cref="bool"/> to a <see cref="Result"/>, CONTINUE when true, or DENY when false</summary>
             protected Result Continue(bool success)
                 => success ? Result.CONTINUE : Result.DENY;
-        }
-
-        private sealed class FilterCollection : IEnumerable<BaseFilter>
-        {
-            /// <summary>Use a List so that we maintain entry order</summary>
-            private readonly IList<BaseFilter> Filters = new List<BaseFilter>();
-
-            public void Add(BaseFilter filter)
-                => this.Filters.Add(filter);
-
-            /// <inheritdoc />
-            public IEnumerator<BaseFilter> GetEnumerator()
-                => this.Filters.GetEnumerator();
-
-            /// <inheritdoc />
-            IEnumerator IEnumerable.GetEnumerator()
-                => this.GetEnumerator();
         }
     }
 }

--- a/src/Objects/AddressFilter.cs
+++ b/src/Objects/AddressFilter.cs
@@ -12,6 +12,12 @@ namespace MyAddressExtractor.Objects {
             /// <summary>A Name for the Filter, which is added to the Debug Stack when run</summary>
             public abstract string Name { get; }
 
+            /// <summary>Runtime </summary>
+            public required Runtime Runtime { get; set; }
+
+            /// <summary>The CLI input configuration</summary>
+            public Config Config => this.Runtime.Config;
+
             public virtual Result ValidateEmailAddress(ref EmailAddress address)
                 => Result.CONTINUE;
 

--- a/src/Objects/Attributes/CommandLineOptionAttribute.cs
+++ b/src/Objects/Attributes/CommandLineOptionAttribute.cs
@@ -1,0 +1,184 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace MyAddressExtractor.Objects.Attributes {
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    internal sealed class CommandLineOptionAttribute : Attribute
+    {
+        /// <summary>Arguments that activate the command option</summary>
+        public readonly string[] Args;
+
+        /// <summary>The Option description that is printed in the Help message</summary>
+        public required string Description { get; init; }
+
+        /// <summary>If the Method returns a <see cref="Config.Writer"/>, the type of information to expect (Printed in the Help message)</summary>
+        public string? Expects { get; init; } = null;
+
+        /// <summary>If the Option must be used exclusively by itself in order to work</summary>
+        public bool Exclusive { get; init; } = false;
+
+        public CommandLineOptionAttribute(params string[] args)
+        {
+            this.Args = args;
+        }
+    }
+
+    internal sealed class CommandLineOption
+    {
+        /// <inheritdoc cref="CommandLineOptionAttribute.Args"/>
+        public readonly string[] Args;
+
+        /// <inheritdoc cref="CommandLineOptionAttribute.Description"/>
+        public readonly string Description;
+
+        /// <inheritdoc cref="CommandLineOptionAttribute.Expects"/>
+        public readonly string? Expects;
+
+        /// <inheritdoc cref="CommandLineOptionAttribute.Exclusive"/>
+        public readonly bool IsExclusive;
+
+        /// <summary>If the Option expects an input</summary>
+        public bool ExpectsArgument => this.MemberInfo switch {
+            null => false,
+            MethodInfo method => method.ReturnType == typeof(Config.Writer),
+            PropertyInfo property => property.CanWrite && property.PropertyType != typeof(bool),
+            _ => false
+        };
+
+        private readonly MemberInfo? MemberInfo;
+
+        public CommandLineOption(MemberInfo method, CommandLineOptionAttribute attribute)
+        {
+            this.Args = this.MapArgs(attribute.Args);
+            this.Description = attribute.Description;
+            this.Expects = attribute.Expects;
+            this.IsExclusive = attribute.Exclusive;
+            this.MemberInfo = method;
+        }
+        public CommandLineOption(string argument, string description)
+        {
+            this.Args = new []{ argument };
+            this.Description = description;
+            this.Expects = null;
+            this.IsExclusive = false;
+            this.MemberInfo = null;
+        }
+
+        public bool IsMatch(string arg)
+            => this.Args.Contains(arg);
+
+        public Config.Writer? Invoke(Config config)
+        {
+            if (this.MemberInfo is null)
+                throw new NotImplementedException("Cannot invoke Options that don't provide a Method");
+            if (this.MemberInfo is MethodInfo method)
+            {
+                if (this.ExpectsArgument) {
+                    object? result = method.Invoke(config, Array.Empty<object>());
+                    return result as Config.Writer;
+                }
+
+                method.Invoke(config, Array.Empty<object>());
+            }
+            else if (this.MemberInfo is PropertyInfo {CanWrite: true} property)
+            {
+                return this.CreateWriter(config, property);
+            }
+
+            return null;
+        }
+
+        public string JoinArgs()
+        {
+            var val = string.Join(", ", this.Args);
+            if (this.ExpectsArgument)
+                val += $" <{this.Expects ?? this.GetExpects()}>";
+            return val;
+        }
+
+        #region Helpers
+
+        private string[] MapArgs(string[] input)
+        {
+            var args = new string[input.Length];
+            for (int i = 0; i < input.Length; i++) {
+                string val = input[i];
+                var r = val.Length is 1 ? 1 : 2;
+
+                args[i] = $"{new string('-', r)}{val}";
+            }
+
+            return args;
+        }
+
+        private Config.Writer? CreateWriter(Config config, PropertyInfo property)
+        {
+            Type type = property.PropertyType;
+
+            if (type == typeof(int))
+            {
+                return input => {
+                    int? min = null;
+                    int? max = null;
+
+                    if (property.GetCustomAttribute<RangeAttribute>() is {} range) {
+                        min = range.Minimum as int?;
+                        max = range.Maximum as int?;
+                    }
+
+                    var val = this.ParseInt(input, min, max);
+                    property.SetValue(config, val);
+                };
+            }
+
+            if (type == typeof(string))
+            {
+                return input => {
+                    property.SetValue(config, input);
+                };
+            }
+
+            if (type == typeof(bool)) {
+                var val = property.GetValue(config) as bool?;
+                property.SetValue(config, val is true);
+                
+                // Bools don't return a writer
+                return null;
+            }
+
+            return property.CanWrite ? throw new NotImplementedException($"Creating Writer for \"{type}\" not implemented") : null;
+        }
+
+        private string GetExpects()
+        {
+            if (this.MemberInfo is PropertyInfo property)
+            {
+                Type type = property.PropertyType;
+                if (type == typeof(int))
+                    return "#";
+                if (type == typeof(string))
+                    return "string";
+            }
+            return "input";
+        }
+
+        #endregion
+        #region Parsers
+
+        private int ParseInt(string value, int? min = null, int? max = null)
+        {
+            if (!int.TryParse(value, out int i))
+                throw new ArgumentException("Value must be a number");
+
+            if (i < min)
+                throw new ArgumentException($"Value cannot be less than {min}");
+
+            if (i > max)
+                throw new ArgumentException($"Value cannot be more than {max}");
+
+            return i;
+        }
+
+        #endregion
+    }
+}

--- a/src/Objects/Attributes/CommandLineOptionAttribute.cs
+++ b/src/Objects/Attributes/CommandLineOptionAttribute.cs
@@ -141,7 +141,7 @@ namespace MyAddressExtractor.Objects.Attributes {
             if (type.IsEnum) {
                 return input => {
                     if (!Enum.TryParse(type, input, ignoreCase: true, out object? value))
-                        throw new ArgumentException("");
+                        throw new ArgumentException($"Invalid value \"{input}\"");
 
                     property.SetValue(config, value);
                 };

--- a/src/Objects/Attributes/CommandLineOptionAttribute.cs
+++ b/src/Objects/Attributes/CommandLineOptionAttribute.cs
@@ -138,10 +138,11 @@ namespace MyAddressExtractor.Objects.Attributes {
                 };
             }
 
-            if (type == typeof(bool)) {
+            if (type == typeof(bool))
+            {
                 var val = property.GetValue(config) as bool?;
-                property.SetValue(config, val is true);
-                
+                property.SetValue(config, val is not true);
+
                 // Bools don't return a writer
                 return null;
             }

--- a/src/Objects/Config.cs
+++ b/src/Objects/Config.cs
@@ -1,0 +1,216 @@
+using System.Reflection;
+using System.Threading.Channels;
+
+namespace MyAddressExtractor.Objects {
+    public sealed class Config {
+        #region Runtime
+
+        private readonly UserPromptLock PromptLock;
+        private readonly CancellationTokenSource ProgramCancellation;
+        public CancellationToken CancellationToken => this.ProgramCancellation.Token;
+
+        #endregion
+        #region Config Options
+
+        public string OutputFilePath { get; private set; } = Defaults.OUTPUT_FILE_PATH;
+        public string ReportFilePath { get; private set; } = Defaults.REPORT_FILE_PATH;
+
+        public bool OperateRecursively { get; private set; } = Defaults.OPERATE_RECURSIVELY;
+        public bool SkipPrompts { get; private set; } = Defaults.SKIP_PROMPTS;
+
+        public int Threads { get; private set; } = Defaults.CHANNELS;
+
+        public bool Debug { get; private set; } = Defaults.DEBUG;
+        public bool Quiet { get; private set; } = Defaults.QUIET;
+
+        #endregion
+
+        public Config()
+        {
+            this.ProgramCancellation = new CancellationTokenSource();
+            this.PromptLock = new UserPromptLock(this.ProgramCancellation);
+        }
+
+        #region CLI Waiters
+
+        internal bool WaitInput(FileCollection files)
+        {
+            // If silent output don't prompt
+            if (this.SkipPrompts)
+                return true;
+
+            while (true)
+            {
+                Console.Write("Press ANY KEY to continue ['Q' to Quit; 'I' for info]: ");
+                var read = Console.ReadKey(intercept: true);
+                Console.WriteLine();
+
+                // No modifiers (shift/ctrl/alt)
+                if (read.Modifiers is 0)
+                {
+                    switch (read.Key)
+                    {
+                        case ConsoleKey.Q:
+                            Output.Write("Exiting");
+                            return false;
+                        case ConsoleKey.I:
+                            Output.Write($"Reading the following {files.Count} files:");
+                            foreach (var file in files)
+                            {
+                                Output.Write($"  [{ByteExtensions.Format(file.Length).PadRight(10)}] {file.FullName}");
+                            }
+                            Console.WriteLine();
+                            continue;
+                        default:
+                            return true;
+                    }
+                }
+            }
+        }
+
+        internal async ValueTask<bool> WaitOnExceptionAsync(CancellationToken cancellation = default)
+            => this.SkipPrompts // If silent output don't prompt
+               || await this.PromptLock.PromptAsync(cancellation);
+
+        internal Task AwaitContinuationAsync(CancellationToken cancellation = default)
+            => this.PromptLock.WaitAsync(cancellation);
+
+        #endregion
+        #region Parsers
+
+        private int ParseInt(string value, int? min = null, int? max = null)
+        {
+            if (!int.TryParse(value, out int i))
+                throw new ArgumentException("Value must be a number");
+
+            if (i < min)
+                throw new ArgumentException($"Value cannot be less than {min}");
+
+            if (i > max)
+                throw new ArgumentException($"Value cannot be more than {max}");
+
+            return i;
+        }
+
+        #endregion
+        #region Setters
+
+        internal Writer? Set(IReadOnlyCollection<string> args, string input) => input switch {
+            "--recursive"
+                => this.SetRecursion(),
+            "-o" or "--output"
+                => this.SetOutputPath(),
+            "-r" or "--report"
+                => this.SetReportPath(),
+            "-y" or "--yes"
+                => this.SetSkipPrompts(),
+            "-v" or "--version"
+                => args.Count > 1 ? throw new ArgumentException($"'{input}' must be the only argument when it is used") : this.ShowVersion(),
+            "-?" or "-h" or "--help"
+                => args.Count > 0 ? throw new ArgumentException($"'{input}' must be the only argument when it is used") : this.ShowUsage(),
+            "--debug"
+                => this.SetDebug(),
+            "-q" or "--quiet"
+                => this.SetQuiet(),
+            "--threads"
+                => this.SetThreads(),
+            _ => throw new ArgumentException($"Unexpected option '{input}'")
+        };
+
+        private Writer? SetRecursion()
+        {
+            this.OperateRecursively = true;
+            return null;
+        }
+
+        private Writer? SetOutputPath()
+        {
+            return value => this.OutputFilePath = value;
+        }
+
+        private Writer? SetReportPath()
+        {
+            return value => this.ReportFilePath = value;
+        }
+
+        private Writer? SetSkipPrompts()
+        {
+            this.SkipPrompts = true;
+            return null;
+        }
+
+        private Writer? SetDebug()
+        {
+            this.Debug = true;
+            return null;
+        }
+
+        private Writer? SetQuiet()
+        {
+            this.Quiet = true;
+            return null;
+        }
+
+        private Writer? SetThreads()
+        {
+            return value => this.Threads = this.ParseInt(value, min: 1, max: 1000);
+        }
+
+        private Writer? ShowUsage()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            Console.WriteLine($"""
+                Syntax: {assembly.GetName().Name} -?
+                Syntax: {assembly.GetName().Name} -v
+                Syntax: {assembly.GetName().Name} <input [input...]> [-o output] [-r report]
+                
+                --help, -h, -?       Help for the command line arguments
+                -v                   Prints the application version
+                
+                input                One or more input file paths
+                -o output            File path to write output file
+                -r report            File path to write report file
+                
+                --debug              Enables debug mode, prints timings and exceptions
+                --threads #          Specifies the number of Tasks to use for parsing Regex
+                --recursive          Recursively enters directories provided to search for files
+                --yes, -y            Skips any prompts asking to continue
+                --quiet, -q          Runs in quiet mode, not as verbose
+            """);
+
+            return null;
+        }
+
+        private Writer? ShowVersion()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            Console.WriteLine(assembly.GetName().Version);
+
+            return null;
+        }
+
+        #endregion
+
+        public Channel<Line> CreateChannel()
+            => Channel.CreateBounded<Line>(new BoundedChannelOptions(this.Threads * 3) {
+                SingleWriter = true, // Only one instance of `ILineReader` is used at a time
+                SingleReader = false,
+                AllowSynchronousContinuations = false // Require Async
+            });
+
+        public static class Defaults {
+            public const string OUTPUT_FILE_PATH = "addresses_output.txt";
+            public const string REPORT_FILE_PATH = "report.txt";
+
+            public const bool OPERATE_RECURSIVELY = false;
+            public const bool SKIP_PROMPTS = false;
+
+            public const int CHANNELS = 4;
+
+            public const bool DEBUG = false;
+            public const bool QUIET = false;
+        }
+
+        internal delegate void Writer(string value);
+    }
+}

--- a/src/Objects/Runtime.cs
+++ b/src/Objects/Runtime.cs
@@ -1,0 +1,220 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Reflection;
+using MyAddressExtractor.Objects.Attributes;
+using MyAddressExtractor.Objects.Readers;
+
+namespace MyAddressExtractor.Objects {
+    public sealed class Runtime {
+        /// <summary>The Runtime Configuration</summary>
+        public readonly Config Config;
+
+        /// <summary>Filters created for filtering <see cref="EmailAddress"/>es</summary>
+        public readonly IEnumerable<AddressFilter.BaseFilter> Filters;
+
+        /// <summary>File Extension Parsers created for Reading file types</summary>
+        private readonly IReadOnlyDictionary<string, FileExtensionParsing> FileExtensions;
+        private readonly FileExtensionParsing UnknownFileExtension = new() { Error = "Unknown Extension" };
+
+        #region Asynchronous Waiting
+
+        private readonly UserPromptLock PromptLock;
+        private readonly CancellationTokenSource ProgramCancellation;
+        public CancellationToken CancellationToken => this.ProgramCancellation.Token;
+
+        #endregion
+
+        public Runtime(Config? config = null)
+        {
+            this.ProgramCancellation = new CancellationTokenSource();
+            this.PromptLock = new UserPromptLock(this.ProgramCancellation);
+
+            this.Config = config ?? new Config();
+            this.Filters = this.CreateFilters();
+            this.FileExtensions = this.CreateExtensions();
+        }
+
+        #region CLI Waiters
+
+        internal bool WaitInput(FileCollection files)
+        {
+            // If silent output don't prompt
+            if (this.Config.SkipPrompts)
+                return true;
+
+            while (true)
+            {
+                Console.Write("Press ANY KEY to continue ['Q' to Quit; 'I' for info]: ");
+                var read = Console.ReadKey(intercept: true);
+                Console.WriteLine();
+
+                // No modifiers (shift/ctrl/alt)
+                if (read.Modifiers is 0)
+                {
+                    switch (read.Key)
+                    {
+                        case ConsoleKey.Q:
+                            Output.Write("Exiting");
+                            return false;
+                        case ConsoleKey.I:
+                            Output.Write($"Reading the following {files.Count} files:");
+                            foreach (var file in files)
+                            {
+                                Output.Write($"  [{ByteExtensions.Format(file.Length).PadRight(10)}] {file.FullName}");
+                            }
+                            Console.WriteLine();
+                            continue;
+                        default:
+                            return true;
+                    }
+                }
+            }
+        }
+
+        internal ValueTask<bool> WaitOnExceptionAsync()
+            => this.WaitOnExceptionAsync(this.CancellationToken);
+
+        internal async ValueTask<bool> WaitOnExceptionAsync(CancellationToken cancellation)
+            => this.Config.SkipExceptions // If silent output don't prompt
+            || await this.PromptLock.PromptAsync(cancellation);
+
+        internal Task AwaitContinuationAsync(CancellationToken cancellation = default)
+            => this.PromptLock.WaitAsync(cancellation);
+
+        #endregion
+        #region Filters
+
+        private FilterCollection CreateFilters()
+        {
+            var filters = new FilterCollection();
+            var types = Assembly.GetExecutingAssembly()
+                .GetTypes()
+                .Where(type => type.IsClass && !type.IsAbstract && type.IsAssignableTo(typeof(AddressFilter.BaseFilter)))
+                .OrderByDescending(type => type.GetCustomAttribute<AddressFilterAttribute>()?.Priority ?? -1);
+            foreach (Type type in types)
+            {
+                if (Activator.CreateInstance(type) is AddressFilter.BaseFilter filter)
+                    filters.Add(filter);
+            }
+
+            return filters;
+        }
+
+        #endregion
+        #region File Extensions
+
+        private IReadOnlyDictionary<string, FileExtensionParsing> CreateExtensions()
+        {
+            var extensions = new ConcurrentDictionary<string, FileExtensionParsing>(StringComparer.OrdinalIgnoreCase);
+
+            // Archives
+            extensions.AddAll(
+                new[] { ".tar", ".gz", ".zip", ".rar", ".7z" },
+                new FileExtensionParsing { Error = "Archive files" }
+            );
+
+            // Images
+            extensions.AddAll(
+                new[] { ".png", ".tif", ".jpg", ".jpeg", ".gif", ".bmp", ".ai", ".psd", ".svg", ".ico" },
+                new FileExtensionParsing { Error = "Image files" }
+            );
+
+            // AudioVideo
+            extensions.AddAll(
+                new[] { ".rec", ".mp3", ".wav", ".mp4", ".mpg", ".mov", ".wmv", ".avi", ".m4v" },
+                new FileExtensionParsing { Error = "Audio/Video files" }
+            );
+
+            // Sql
+            extensions.AddAll(
+                new[] { ".frm", ".ibd", ".myi", ".myd" },
+                new FileExtensionParsing { Error = "Sql files" }
+            );
+
+            // Code
+            extensions.AddAll(
+                new[] { ".go", ".py", ".js", ".yml", ".php", ".c", ".sh", ".css", ".less", ".npmignore", ".groovy", ".scala", ".sass", ".ascx", ".markdown", ".bash", ".sln", ".h", ".ts", ".cs", ".aspx", ".csproj", ".nupk", ".suo", ".asax", ".resx", ".refesh", ".ipch" },
+                new FileExtensionParsing { Error = "Code files" }
+            );
+
+            // Source Control
+            extensions.AddAll(
+                new[] { ".svn-base", ".gitignore", ".gitattributes", ".pack" },
+                new FileExtensionParsing { Error = "Source-control files" }
+            );
+
+            // Executables
+            extensions.AddAll(
+                new[] { ".exe", ".dll", ".apk", ".jar", ".java",  "bin" },
+                new FileExtensionParsing { Error = "Executables" }
+            );
+
+            // Other
+            extensions.AddAll(
+                new[] { ".msi", ".flv", ".swf", ".pdb", ".brd", ".hprof", ".lock", ".docker", ".ttf", ".woff", ".woff2", ".pem", ".crt" },
+                new FileExtensionParsing { Error = "Unsupported" }
+            );
+
+            // A set of all extensions that should be eventually supported
+            // These are overriden using Reflection and do not need to be removed
+            extensions.AddAll(
+                new[] { ".log", ".json", ".txt", ".sql", ".xml", ".sample", ".csv", ".tsv", ".odt", ".docx", ".pptx", ".xls", ".doc", ".ppt", ".pdf", ".rdb" },
+                new FileExtensionParsing { Error = "Not currently supported" }
+            );
+
+            var types = Assembly.GetExecutingAssembly()
+                .GetTypes()
+                .Where(type => type.IsClass && !type.IsAbstract && type.IsAssignableTo(typeof(ILineReader)));
+            foreach (var type in types)
+            {
+                if (type.GetCustomAttribute<ExtensionTypesAttribute>() is {} attribute)
+                {
+                    var parsing = new FileExtensionParsing(type);
+
+                    // Use the setter to override any other instances
+                    foreach (string extension in attribute.Extensions)
+                        extensions[extension] = parsing;
+                }
+            }
+
+            return extensions;
+        }
+
+        internal FileExtensionParsing GetExtension(string extension)
+            => this.FileExtensions.GetValueOrDefault(extension, this.UnknownFileExtension);
+
+        internal FileExtensionParsing GetExtension(FileInfo info)
+            => this.FileExtensions.GetValueOrDefault(info.Extension, this.UnknownFileExtension);
+
+        internal FileExtensionParsing GetExtensionFromPath(string path)
+            => this.FileExtensions.GetValueOrDefault(Path.GetExtension(path), this.UnknownFileExtension);
+
+        #endregion
+        #region Debugging
+
+        public bool ShouldDebug(Exception ex)
+            => this.Config.Debug && ex is not NotImplementedException;
+
+        #endregion
+        #region Inner classes
+
+        private sealed class FilterCollection : IEnumerable<AddressFilter.BaseFilter>
+        {
+            /// <summary>Use a List so that we maintain entry order</summary>
+            private readonly IList<AddressFilter.BaseFilter> Filters = new List<AddressFilter.BaseFilter>();
+
+            public void Add(AddressFilter.BaseFilter filter)
+                => this.Filters.Add(filter);
+
+            /// <inheritdoc />
+            public IEnumerator<AddressFilter.BaseFilter> GetEnumerator()
+                => this.Filters.GetEnumerator();
+
+            /// <inheritdoc />
+            IEnumerator IEnumerable.GetEnumerator()
+                => this.GetEnumerator();
+        }
+        
+        #endregion
+    }
+}

--- a/src/Objects/Runtime.cs
+++ b/src/Objects/Runtime.cs
@@ -94,7 +94,12 @@ namespace MyAddressExtractor.Objects {
             foreach (Type type in types)
             {
                 if (Activator.CreateInstance(type) is AddressFilter.BaseFilter filter)
+                {
+                    var property = type.GetProperty(nameof(AddressFilter.BaseFilter.Runtime));
+                    property!.SetValue(filter, this);
+
                     filters.Add(filter);
+                }
             }
 
             return filters;
@@ -169,7 +174,7 @@ namespace MyAddressExtractor.Objects {
             {
                 if (type.GetCustomAttribute<ExtensionTypesAttribute>() is {} attribute)
                 {
-                    var parsing = new FileExtensionParsing(type);
+                    var parsing = new FileExtensionParsing(this, type);
 
                     // Use the setter to override any other instances
                     foreach (string extension in attribute.Extensions)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -24,10 +24,10 @@ namespace MyAddressExtractor
         {
             IList<string> inputFilePaths;
 
-            CommandLineProcessor config;
+            Config config;
             try
             {
-                config = new CommandLineProcessor(args, out inputFilePaths);
+                config = CommandLineProcessor.Parse(args, out inputFilePaths);
             }
             catch (ArgumentException ae)
             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -42,7 +42,7 @@ namespace MyAddressExtractor
 
             try
             {
-                var runtime = new Runtime();
+                var runtime = new Runtime(config);
                 var files = new FileCollection(runtime, inputFilePaths);
 
                 if (!runtime.WaitInput(files))

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MyAddressExtractor;
+using MyAddressExtractor.Objects;
 
 namespace AddressExtractorTest
 {
@@ -232,6 +233,15 @@ namespace AddressExtractorTest
 
         #region Wrappers
 
+        private readonly Runtime Runtime;
+        private readonly AddressExtractor Extractor;
+
+        public AddressExtractorTests()
+        {
+            this.Runtime = new Runtime();
+            this.Extractor = new AddressExtractor(this.Runtime);
+        }
+
         /// <summary>
         /// Extract the addresses from the Address Extractor and wrap it into a set
         /// Wrapping the <see cref="IEnumerable{String}"/> here instead of within the Method
@@ -239,10 +249,9 @@ namespace AddressExtractorTest
         /// </summary>
         private async ValueTask<HashSet<string>> ExtractAddressesAsync(string input)
         {
-            var extractor = new AddressExtractor();
             var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            await foreach(var address in extractor.ExtractAddressesAsync(input))
+            await foreach(var address in this.Extractor.ExtractAddressesAsync(input))
                 set.Add(address);
 
             return set;
@@ -251,13 +260,12 @@ namespace AddressExtractorTest
         private async ValueTask<HashSet<string>> ExtractAddressesFromFileAsync(string path, CancellationToken cancellation = default)
         {
             // Arrange
-            var extractor = new AddressExtractor();
             var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var parser = FileExtensionParsing.GetFromPath(path);
+            var parser = this.Runtime.GetExtensionFromPath(path);
 
             await using (var reader = parser.GetReader(path))
             {
-                await foreach(var address in extractor.ExtractFileAddressesAsync(reader, cancellation))
+                await foreach(var address in this.Extractor.ExtractFileAddressesAsync(reader, cancellation))
                     set.Add(address);
             }
             return set;

--- a/test/CommandLineProcessorTests.cs
+++ b/test/CommandLineProcessorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MyAddressExtractor;
+using MyAddressExtractor.Objects;
 
 namespace AddressExtractorTest
 {
@@ -15,7 +16,7 @@ namespace AddressExtractorTest
             var args = Array.Empty<string>();
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         [TestMethod]
@@ -25,7 +26,7 @@ namespace AddressExtractorTest
             var args = new[] { "-o", "output" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         [TestMethod]
@@ -35,7 +36,7 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-o" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         [TestMethod]
@@ -45,7 +46,7 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-r" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         [TestMethod]
@@ -55,7 +56,7 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-o", "-r", "report" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         [TestMethod]
@@ -65,7 +66,7 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-r", "-o", "output" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         [TestMethod]
@@ -75,7 +76,7 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         [TestMethod]
@@ -85,7 +86,7 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-z" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         #endregion
@@ -100,7 +101,7 @@ namespace AddressExtractorTest
                 var args = new[] { option };
 
                 // Act and Assert
-                var config = new CommandLineProcessor(args, out _);
+                var config = CommandLineProcessor.Parse(args, out _);
                 // Successful if no exception thrown
             }
         }
@@ -112,7 +113,7 @@ namespace AddressExtractorTest
             var args = new[] { "input", "-?" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         [TestMethod]
@@ -122,7 +123,7 @@ namespace AddressExtractorTest
             var args = new[] { "-?", "input" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         #region Version flag
@@ -137,7 +138,7 @@ namespace AddressExtractorTest
                 var args = new[] { option };
 
                 // Act and Assert
-                var config = new CommandLineProcessor(args, out _);
+                var config = CommandLineProcessor.Parse(args, out _);
                 // Successful if no exception thrown
             }
         }
@@ -149,7 +150,7 @@ namespace AddressExtractorTest
             var args = new[] { "input", "-v" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         [TestMethod]
@@ -159,7 +160,7 @@ namespace AddressExtractorTest
             var args = new[] { "-v", "input" };
 
             // Act and Assert
-            Assert.ThrowsException<ArgumentException>(() => new CommandLineProcessor(args, out _));
+            Assert.ThrowsException<ArgumentException>(() => CommandLineProcessor.Parse(args, out _));
         }
 
         #endregion
@@ -171,7 +172,7 @@ namespace AddressExtractorTest
             var args = new[] { "input", "--debug" };
 
             // Act and Assert
-            var config = new CommandLineProcessor(args, out _);
+            var config = CommandLineProcessor.Parse(args, out _);
             Assert.IsTrue(config.Debug, "Debug mode should be enabled");
         }
 
@@ -185,7 +186,7 @@ namespace AddressExtractorTest
                 var args = new[] { "input", option };
 
                 // Act and Assert
-                var config = new CommandLineProcessor(args, out _);
+                var config = CommandLineProcessor.Parse(args, out _);
                 Assert.IsTrue(config.SkipPrompts, "Skipping prompts should be enabled");
             }
         }
@@ -200,13 +201,13 @@ namespace AddressExtractorTest
             var args = new[] { "input1" };
 
             // Act
-            var config = new CommandLineProcessor(args, out IList<string> inputs);
+            var config = CommandLineProcessor.Parse(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(config.OutputFilePath, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
-            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.OutputFilePath, Config.Defaults.OUTPUT_FILE_PATH);
+            Assert.AreEqual(config.ReportFilePath, Config.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -216,14 +217,14 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "input2" };
 
             // Act
-            var config = new CommandLineProcessor(args, out IList<string> inputs);
+            var config = CommandLineProcessor.Parse(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[1]);
-            Assert.AreEqual(config.OutputFilePath, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
-            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.OutputFilePath, Config.Defaults.OUTPUT_FILE_PATH);
+            Assert.AreEqual(config.ReportFilePath, Config.Defaults.REPORT_FILE_PATH);
         }
 
         #endregion
@@ -235,13 +236,13 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-o", "output" };
 
             // Act
-            var config = new CommandLineProcessor(args, out IList<string> inputs);
+            var config = CommandLineProcessor.Parse(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(config.OutputFilePath, args[2]);
-            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.ReportFilePath, Config.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -251,12 +252,12 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-r", "report" };
 
             // Act
-            var config = new CommandLineProcessor(args, out IList<string> inputs);
+            var config = CommandLineProcessor.Parse(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
             Assert.AreEqual(inputs[0], args[0]);
-            Assert.AreEqual(config.OutputFilePath, CommandLineProcessor.Defaults.OUTPUT_FILE_PATH);
+            Assert.AreEqual(config.OutputFilePath, Config.Defaults.OUTPUT_FILE_PATH);
             Assert.AreEqual(config.ReportFilePath, args[2]);
         }
 
@@ -267,7 +268,7 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-o", "output", "-r", "report" };
 
             // Act
-            var config = new CommandLineProcessor(args, out IList<string> inputs);
+            var config = CommandLineProcessor.Parse(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
@@ -283,7 +284,7 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-r", "report", "-o", "output" };
 
             // Act
-            var config = new CommandLineProcessor(args, out IList<string> inputs);
+            var config = CommandLineProcessor.Parse(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 1);
@@ -299,14 +300,14 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "input2", "-o", "output" };
 
             // Act
-            var config = new CommandLineProcessor(args, out IList<string> inputs);
+            var config = CommandLineProcessor.Parse(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[1]);
             Assert.AreEqual(config.OutputFilePath, args[3]);
-            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.ReportFilePath, Config.Defaults.REPORT_FILE_PATH);
         }
 
         [TestMethod]
@@ -316,14 +317,14 @@ namespace AddressExtractorTest
             var args = new[] { "input1", "-o", "output", "input2" };
 
             // Act
-            var config = new CommandLineProcessor(args, out IList<string> inputs);
+            var config = CommandLineProcessor.Parse(args, out IList<string> inputs);
 
             // Assert
             Assert.AreEqual(inputs.Count, 2);
             Assert.AreEqual(inputs[0], args[0]);
             Assert.AreEqual(inputs[1], args[3]);
             Assert.AreEqual(config.OutputFilePath, args[2]);
-            Assert.AreEqual(config.ReportFilePath, CommandLineProcessor.Defaults.REPORT_FILE_PATH);
+            Assert.AreEqual(config.ReportFilePath, Config.Defaults.REPORT_FILE_PATH);
         }
     }
 }

--- a/test/LegacyTests.cs
+++ b/test/LegacyTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MyAddressExtractor;
+using MyAddressExtractor.Objects;
 
 namespace AddressExtractorTest
 {
@@ -153,7 +154,7 @@ namespace AddressExtractorTest
         /// <returns></returns>
         private async ValueTask<bool> IsValidEmailAsync(string? sourceEmail)
         {
-            var sut = new AddressExtractor();
+            var sut = new AddressExtractor(new Runtime());
             await foreach (var _ in sut.ExtractAddressesAsync(sourceEmail))
                 return true;
             return false;


### PR DESCRIPTION
Refactored the `CommandLineProcessor` to spit out a `Config` class that holds the contents of any CLI inputs. `Config` uses reflection to make implementing various options a lot easier, instead of just continuing on the existing switch statement now that there are a lot more options.

The current growing switch:

https://github.com/HaveIBeenPwned/EmailAddressExtractor/blob/6e638a199e5fb46e5ab42782b1fe4995c476750e/src/CommandLineProcessor.cs#L68-L107

----

Since config options are now picked up with reflection, the `--help`/`-h`/`-?` option now automatically updates, as it was missing a lot of options for awhile until f63e4b6

The `-o` and `-r` options are now simply as follows:

```csharp
/// <summary>The path to write collected <see cref="EmailAddress"/>es to</summary>
[CommandLineOption("o", "output", Description = "File path to write output file", Expects = "path")]
public string OutputFilePath { get; private set; } = Defaults.OUTPUT_FILE_PATH;

/// <summary>The path to write the summary report to</summary>
[CommandLineOption("r", "report", Description = "File path to write report file", Expects = "path")]
public string ReportFilePath { get; private set; } = Defaults.REPORT_FILE_PATH;
```

`--help` will now output:

```
Syntax: AddressExtractor -?
Syntax: AddressExtractor -v
Syntax: AddressExtractor <input [input...]> [-o output] [-r report]

  input                 One or more input file paths
  --debug               Enables debug mode, prints timings and exceptions
  -?, -h, --help        Help for the command line arguments
  -o, --output <path>   File path to write output file
  -q, --quiet           Runs in quiet mode, not as verbose
  --recursive           Recursively enters directories provided to search for files
  -r, --report <path>   File path to write report file
  --skip-exceptions     Skips any continue prompts on exceptions
  --threads <#>         Specifies the number of Tasks to use for parsing Regex
  -v, --version         Prints the application version
  -y, --yes             Skips any normal continue prompts
```

----

Fixed #59 

I've now added a separate option for prompts on exceptions: `--skip-exceptions`

```csharp
/// <summary>If the prompt to Continue on Exceptions should be skipped</summary>
[CommandLineOption("skip-exceptions", Description = "Skips any continue prompts on exceptions")]
public bool SkipExceptions { get; private set; } = Defaults.SKIP_EXCEPTIONS;
```

----

I also slightly refactored Email Filters and File Readers to be able to be passed the Config, so if they need to be configured in any way its now doable. Previously both of these things were constructed staticly. Now they've been moved into a `Runtime` class

----

It was suggested in #61 to be able to control whether `rfc3696` is handled or not. I've not done anything to implement it here but if it's something you think is doable without creating too many issues, being able to check in Filters what the config mode is is now possible.

Creating a config option for this is now also very easy:

```csharp
enum Mode
{
    NONE,
    RFC3696
}

[CommandLineOption("mode", Description = "Specify a mode of operation")]
public Mode Mode { get; private set; } = Mode.NONE;
```

This would enable something like `--mode rfc3696`