### PR TITLE
Resolves #66

### DIFF
--- a/src/AddressExtractor.csproj
+++ b/src/AddressExtractor.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>11</LangVersion>
+    <RootNamespace>MyAddressExtractor</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Objects/Filters/LengthFilter.cs
+++ b/src/Objects/Filters/LengthFilter.cs
@@ -1,13 +1,26 @@
 using MyAddressExtractor.Objects.Attributes;
 
 namespace MyAddressExtractor.Objects.Filters {
+    /// <summary>
+    /// Parse out bad emails in the
+    /// </summary>
     [AddressFilter(Priority = 1000)]
     public sealed class LengthFilter : AddressFilter.BaseFilter {
+        /// <summary>The entire email address (alias + domain) should not be any longer than this</summary>
+        public const int TOTAL_LENGTH = 255;
+
+        /// <summary>Email Aliases should not be any longer than this</summary>
+        public const int ALIAS_LENGTH = 64;
+
         public override string Name => "Check length";
 
         /// <inheritdoc />
         public override Result ValidateEmailAddress(ref EmailAddress address)
             // Use the match position to validate too long of a length so we don't have to allocate the substring
-            => this.Continue(address.Length <= 255);
+            => this.Continue(
+                address.Length <= LengthFilter.TOTAL_LENGTH
+                &&
+                address.Username.Length <= LengthFilter.ALIAS_LENGTH
+            );
     }
 }

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MyAddressExtractor;
 using MyAddressExtractor.Objects;
+using MyAddressExtractor.Objects.Filters;
 
 namespace AddressExtractorTest
 {
@@ -261,7 +262,7 @@ namespace AddressExtractorTest
         public async Task AliasOf64CharsIsValid()
         {
             // Arrange
-            var ALIAS = new string('a', 64);
+            var ALIAS = new string('a', LengthFilter.ALIAS_LENGTH);
             var INPUT = $"{ALIAS}@example.com";
 
             // Act
@@ -275,7 +276,7 @@ namespace AddressExtractorTest
         public async Task AliasLongerThan64CharsIsInvalid()
         {
             // Arrange
-            var ALIAS = new string('a', 65);
+            var ALIAS = new string('a', LengthFilter.ALIAS_LENGTH + 1);
             var INPUT = $"{ALIAS}@example.com";
 
             // Act


### PR DESCRIPTION
Resolves #66 - Simply modified the existing `LengthFilter` to also filter out bad Aliases.

As much as we're all Regex wizards, it's easier to simply filter out bad results after they've been caught than to try and wedge a `{,64}` into a new matching group.

Used the existing length filter where emails >256 were being filtered out