### PR TITLE
Updated the root namespace

### DIFF
--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -1,10 +1,10 @@
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
-using MyAddressExtractor.Objects;
-using MyAddressExtractor.Objects.Performance;
-using MyAddressExtractor.Objects.Readers;
+using HaveIBeenPwned.AddressExtractor.Objects;
+using HaveIBeenPwned.AddressExtractor.Objects.Performance;
+using HaveIBeenPwned.AddressExtractor.Objects.Readers;
 
-namespace MyAddressExtractor
+namespace HaveIBeenPwned.AddressExtractor
 {
     public partial class AddressExtractor
     {

--- a/src/AddressExtractor.csproj
+++ b/src/AddressExtractor.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>11</LangVersion>
-    <RootNamespace>MyAddressExtractor</RootNamespace>
+    <RootNamespace>HaveIBeenPwned.AddressExtractor</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -2,10 +2,10 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 using System.Threading.Channels;
-using MyAddressExtractor.Objects;
-using MyAddressExtractor.Objects.Performance;
+using HaveIBeenPwned.AddressExtractor.Objects;
+using HaveIBeenPwned.AddressExtractor.Objects.Performance;
 
-namespace MyAddressExtractor {
+namespace HaveIBeenPwned.AddressExtractor {
     public class AddressExtractorMonitor : IAsyncDisposable {
         private readonly Runtime Runtime;
         private Config Config => this.Runtime.Config;

--- a/src/CommandLineProcessor.cs
+++ b/src/CommandLineProcessor.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
-using MyAddressExtractor.Objects;
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor
+namespace HaveIBeenPwned.AddressExtractor
 {
     public class CommandLineProcessor
     {

--- a/src/Count.cs
+++ b/src/Count.cs
@@ -1,4 +1,4 @@
-namespace MyAddressExtractor {
+namespace HaveIBeenPwned.AddressExtractor {
     /// <summary>
     /// A simple glorified <see cref="int"/> wrapper.
     /// Allows storing the <see cref="Count"/> inside of any <see cref="IDictionary{TKey,TValue}"/> and accesing the value by reference

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics;
 using System.Reflection;
-using MyAddressExtractor.Objects;
+using HaveIBeenPwned.AddressExtractor.Objects;
 
-namespace MyAddressExtractor {
+namespace HaveIBeenPwned.AddressExtractor {
     public static class Extensions {
         public static void AddAll<TKey, TVal>(this IDictionary<TKey, TVal> dictionary, IEnumerable<TKey> keys, TVal value)
         {

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -1,8 +1,8 @@
 using System.Collections;
 using System.Collections.Concurrent;
-using MyAddressExtractor.Objects;
+using HaveIBeenPwned.AddressExtractor.Objects;
 
-namespace MyAddressExtractor {
+namespace HaveIBeenPwned.AddressExtractor {
     internal sealed class FileCollection : IEnumerable<FileInfo>
     {
         private readonly Runtime Runtime;

--- a/src/FileExtensionParsing.cs
+++ b/src/FileExtensionParsing.cs
@@ -1,8 +1,8 @@
 using System.Reflection;
-using MyAddressExtractor.Objects;
-using MyAddressExtractor.Objects.Readers;
+using HaveIBeenPwned.AddressExtractor.Objects;
+using HaveIBeenPwned.AddressExtractor.Objects.Readers;
 
-namespace MyAddressExtractor {
+namespace HaveIBeenPwned.AddressExtractor {
     internal sealed class FileExtensionParsing
     {
         public bool Read => this.Error is null;

--- a/src/Objects/AddressFilter.cs
+++ b/src/Objects/AddressFilter.cs
@@ -1,6 +1,6 @@
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects {
+namespace HaveIBeenPwned.AddressExtractor.Objects {
     public sealed class AddressFilter {
         /// <summary>
         /// A base class for checking whether an Email Address should be filtered out

--- a/src/Objects/Attributes/AddressFilterAttribute.cs
+++ b/src/Objects/Attributes/AddressFilterAttribute.cs
@@ -1,4 +1,4 @@
-namespace MyAddressExtractor.Objects.Attributes {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Attributes {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class AddressFilterAttribute : Attribute {
         public int Priority { get; set; } = 0;

--- a/src/Objects/Attributes/CommandLineOptionAttribute.cs
+++ b/src/Objects/Attributes/CommandLineOptionAttribute.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
-namespace MyAddressExtractor.Objects.Attributes {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Attributes {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     internal sealed class CommandLineOptionAttribute : Attribute
     {

--- a/src/Objects/Attributes/ExtensionTypesAttribute.cs
+++ b/src/Objects/Attributes/ExtensionTypesAttribute.cs
@@ -1,4 +1,4 @@
-namespace MyAddressExtractor.Objects.Attributes {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Attributes {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     public sealed class ExtensionTypesAttribute : Attribute
     {

--- a/src/Objects/Bytes.cs
+++ b/src/Objects/Bytes.cs
@@ -1,4 +1,4 @@
-namespace MyAddressExtractor.Objects {
+namespace HaveIBeenPwned.AddressExtractor.Objects {
     public enum Bytes
     {
         BYTE = 0,

--- a/src/Objects/Config.cs
+++ b/src/Objects/Config.cs
@@ -3,9 +3,9 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Channels;
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects {
+namespace HaveIBeenPwned.AddressExtractor.Objects {
     public sealed class Config {
         #region Options
 

--- a/src/Objects/EmailAddress.cs
+++ b/src/Objects/EmailAddress.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 
-namespace MyAddressExtractor.Objects {
+namespace HaveIBeenPwned.AddressExtractor.Objects {
     public struct EmailAddress
     {
         private readonly Match Match;

--- a/src/Objects/Filters/DomainFilter.cs
+++ b/src/Objects/Filters/DomainFilter.cs
@@ -1,6 +1,6 @@
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects.Filters {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Filters {
     [AddressFilter(Priority = 900)]
     public sealed class DomainFilter : AddressFilter.BaseFilter {
         public override string Name => "Domain filter";

--- a/src/Objects/Filters/InvalidAddressFilter.cs
+++ b/src/Objects/Filters/InvalidAddressFilter.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects.Filters {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Filters {
     /// <summary>
     /// A negative-regex pattern for filtering out bad emails
     /// </summary>

--- a/src/Objects/Filters/LengthFilter.cs
+++ b/src/Objects/Filters/LengthFilter.cs
@@ -1,6 +1,6 @@
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects.Filters {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Filters {
     /// <summary>
     /// Parse out bad emails in the
     /// </summary>

--- a/src/Objects/Filters/QuotesFilter.cs
+++ b/src/Objects/Filters/QuotesFilter.cs
@@ -1,4 +1,4 @@
-namespace MyAddressExtractor.Objects.Filters {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Filters {
     public sealed class QuotesFilter : AddressFilter.BaseFilter {
         private static readonly object[] JUNK_CHARS = { '"', '\'', "\\\"" };
 

--- a/src/Objects/Filters/StrictMatchFilter.cs
+++ b/src/Objects/Filters/StrictMatchFilter.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects.Filters {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Filters {
     [AddressFilter(Priority = 990)]
     public sealed partial class StrictMatchFilter : AddressFilter.BaseFilter
     {

--- a/src/Objects/Filters/TldFilter.cs
+++ b/src/Objects/Filters/TldFilter.cs
@@ -3,7 +3,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace MyAddressExtractor.Objects.Filters {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Filters {
     public sealed class TldFilter : AddressFilter.BaseFilter {
         private const string IANA = "https://data.iana.org/TLD/tlds-alpha-by-domain.txt";
         private const string PATH = "tld.json";

--- a/src/Objects/Line.cs
+++ b/src/Objects/Line.cs
@@ -1,4 +1,4 @@
-namespace MyAddressExtractor.Objects
+namespace HaveIBeenPwned.AddressExtractor.Objects
 {
     /// <summary>
     /// A line read from a file

--- a/src/Objects/Output.cs
+++ b/src/Objects/Output.cs
@@ -1,6 +1,6 @@
 using System.Globalization;
 
-namespace MyAddressExtractor.Objects
+namespace HaveIBeenPwned.AddressExtractor.Objects
 {
     public static class Output
     {

--- a/src/Objects/Performance/DebugPerformanceStack.cs
+++ b/src/Objects/Performance/DebugPerformanceStack.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 
-namespace MyAddressExtractor.Objects.Performance {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Performance {
     public sealed class DebugPerformanceStack : IPerformanceStack {
         private readonly DebugPerformanceStack? Parent;
         private readonly NodeAverage Node;

--- a/src/Objects/Performance/IPerformanceStack.cs
+++ b/src/Objects/Performance/IPerformanceStack.cs
@@ -1,4 +1,4 @@
-namespace MyAddressExtractor.Objects.Performance {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Performance {
     /// <summary>
     /// A performance stack object for debugging performance
     /// </summary>

--- a/src/Objects/Readers/CompressedXmlReader.cs
+++ b/src/Objects/Readers/CompressedXmlReader.cs
@@ -2,7 +2,7 @@ using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using System.Xml;
 
-namespace MyAddressExtractor.Objects.Readers
+namespace HaveIBeenPwned.AddressExtractor.Objects.Readers
 {
     internal abstract class CompressedXmlReader : ILineReader
     {
@@ -22,7 +22,7 @@ namespace MyAddressExtractor.Objects.Readers
             {
                 foreach (ZipArchiveEntry entry in archive.Entries)
                 {
-                    if (IsMatch(entry.FullName))
+                    if (this.IsMatch(entry.FullName))
                     {
                         XmlReaderSettings settings = new XmlReaderSettings();
                         settings.Async = true;

--- a/src/Objects/Readers/DocumentReader.cs
+++ b/src/Objects/Readers/DocumentReader.cs
@@ -1,6 +1,6 @@
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects.Readers {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Readers {
     [ExtensionTypes(".doc")]
     public sealed class DocumentReader : ILineReader
     {

--- a/src/Objects/Readers/ILineReader.cs
+++ b/src/Objects/Readers/ILineReader.cs
@@ -1,4 +1,4 @@
-namespace MyAddressExtractor.Objects.Readers {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Readers {
     public interface ILineReader : IAsyncDisposable
     {
         /// <summary>Read and return string segments to be checked for email addresses</summary>

--- a/src/Objects/Readers/OpenDocumentXmlReader.cs
+++ b/src/Objects/Readers/OpenDocumentXmlReader.cs
@@ -1,6 +1,6 @@
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects.Readers
+namespace HaveIBeenPwned.AddressExtractor.Objects.Readers
 {
     /// <summary>Open Document - ISO 26300</summary>
     [ExtensionTypes(".odt")]

--- a/src/Objects/Readers/OpenOfficeXmlReader.cs
+++ b/src/Objects/Readers/OpenOfficeXmlReader.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects.Readers
+namespace HaveIBeenPwned.AddressExtractor.Objects.Readers
 {
     /// <summary>Open Office XML - ISO 29500</summary>
     [ExtensionTypes(".docx", ".pptx")]

--- a/src/Objects/Readers/PdfReader.cs
+++ b/src/Objects/Readers/PdfReader.cs
@@ -1,6 +1,6 @@
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects.Readers {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Readers {
     [ExtensionTypes(".pdf")]
     public sealed class PdfReader : ILineReader
     {

--- a/src/Objects/Readers/PlainTextReader.cs
+++ b/src/Objects/Readers/PlainTextReader.cs
@@ -1,8 +1,8 @@
 using System.Runtime.CompilerServices;
 using System.Text;
-using MyAddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
 
-namespace MyAddressExtractor.Objects.Readers {
+namespace HaveIBeenPwned.AddressExtractor.Objects.Readers {
     [ExtensionTypes(".log", ".json", ".txt", ".sql", ".xml", ".sample", ".csv", ".tsv")]
     internal sealed class PlainTextReader : ILineReader
     {

--- a/src/Objects/Result.cs
+++ b/src/Objects/Result.cs
@@ -1,4 +1,4 @@
-namespace MyAddressExtractor.Objects {
+namespace HaveIBeenPwned.AddressExtractor.Objects {
     public enum Result
     {
         /// <summary>Your <see cref="AddressFilter.BaseFilter"/> is certain the the <see cref="EmailAddress"/> is VALID</summary>

--- a/src/Objects/Runtime.cs
+++ b/src/Objects/Runtime.cs
@@ -1,10 +1,10 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Reflection;
-using MyAddressExtractor.Objects.Attributes;
-using MyAddressExtractor.Objects.Readers;
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
+using HaveIBeenPwned.AddressExtractor.Objects.Readers;
 
-namespace MyAddressExtractor.Objects {
+namespace HaveIBeenPwned.AddressExtractor.Objects {
     public sealed class Runtime {
         /// <summary>The Runtime Configuration</summary>
         public readonly Config Config;

--- a/src/Objects/TimeUnit.cs
+++ b/src/Objects/TimeUnit.cs
@@ -1,11 +1,11 @@
-namespace MyAddressExtractor.Objects {
+namespace HaveIBeenPwned.AddressExtractor.Objects {
     public enum TimeUnit : long {
         MICROSECONDS = 1,
-        MILLISECONDS = MICROSECONDS * 1000,
-        SECONDS = MILLISECONDS * 1000,
-        MINUTES = SECONDS * 60,
-        HOURS = MINUTES * 60,
-        DAYS = HOURS * 24
+        MILLISECONDS = TimeUnit.MICROSECONDS * 1000,
+        SECONDS = TimeUnit.MILLISECONDS * 1000,
+        MINUTES = TimeUnit.SECONDS * 60,
+        HOURS = TimeUnit.MINUTES * 60,
+        DAYS = TimeUnit.HOURS * 24
     }
 
     public static class TimeUnitExtensions

--- a/src/Objects/UserPromptLock.cs
+++ b/src/Objects/UserPromptLock.cs
@@ -1,6 +1,6 @@
 using Microsoft.VisualStudio.Threading;
 
-namespace MyAddressExtractor.Objects {
+namespace HaveIBeenPwned.AddressExtractor.Objects {
     internal sealed class UserPromptLock {
         /// <summary>A Semaphore with a single handle, so multiple Tasks cannot prompt</summary>
         private readonly SemaphoreSlim Semaphore = new(1);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,10 +1,10 @@
 ﻿using System.Runtime.CompilerServices;
-using MyAddressExtractor.Objects;
-using MyAddressExtractor.Objects.Performance;
+using HaveIBeenPwned.AddressExtractor.Objects;
+using HaveIBeenPwned.AddressExtractor.Objects.Performance;
 
 [assembly:InternalsVisibleTo("AddressExtractorTest")]
 
-namespace MyAddressExtractor
+namespace HaveIBeenPwned.AddressExtractor
 {
     public class Program
     {

--- a/test/AddressExtractorTest.csproj
+++ b/test/AddressExtractorTest.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>11</LangVersion>
+    <RootNamespace>HaveIBeenPwned.AddressExtractor.Tests</RootNamespace>
   </PropertyGroup>
 
 <ItemGroup>

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MyAddressExtractor;
-using MyAddressExtractor.Objects;
-using MyAddressExtractor.Objects.Filters;
+﻿using HaveIBeenPwned.AddressExtractor.Objects;
+using HaveIBeenPwned.AddressExtractor.Objects.Filters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace AddressExtractorTest
+namespace HaveIBeenPwned.AddressExtractor.Tests
 {
     [TestClass]
     public class AddressExtractorTests

--- a/test/CommandLineProcessorTests.cs
+++ b/test/CommandLineProcessorTests.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MyAddressExtractor;
-using MyAddressExtractor.Objects;
+﻿using HaveIBeenPwned.AddressExtractor.Objects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace AddressExtractorTest
+namespace HaveIBeenPwned.AddressExtractor.Tests
 {
     [TestClass]
     public class CommandLineProcessorTests

--- a/test/LegacyTests.cs
+++ b/test/LegacyTests.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MyAddressExtractor;
-using MyAddressExtractor.Objects;
+﻿using HaveIBeenPwned.AddressExtractor.Objects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace AddressExtractorTest
+namespace HaveIBeenPwned.AddressExtractor.Tests
 {
     [TestClass]
     public class LegacyTests


### PR DESCRIPTION
Not a very crazy update

A simple automatic refactor, changed the root namespace from `MyAddressExtractor` to `HaveIBeenPwned.AddressExtractor`, all class files updated to reflect the change