### PR TITLE
Replaces '.Replace' calls with a Regex

### DIFF
--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -93,15 +93,7 @@ namespace HaveIBeenPwned.AddressExtractor
                     if (valid is Result.DENY)
                         continue;
 
-                    yield return address.Full
-                        // Simple cleanups that may be possible via the regex
-                        .Replace("'", string.Empty)
-                        .Replace("!", string.Empty)
-                        .Replace("`", string.Empty)
-                        .Replace("{", string.Empty)
-                        .Replace("#", string.Empty)
-                        .Replace(@"\n", string.Empty)
-                        .Replace("\\\"", string.Empty);
+                    yield return address.Full;
                 }
             }
         }

--- a/src/Objects/Filters/ReplaceInvalidFilter.cs
+++ b/src/Objects/Filters/ReplaceInvalidFilter.cs
@@ -1,0 +1,29 @@
+using System.Text.RegularExpressions;
+
+namespace HaveIBeenPwned.AddressExtractor.Objects.Filters {
+    /// <summary>
+    /// Checks if the full email starts with specifically illegal characters and trims them until there are no more illegal characters.    /// </summary>
+    public partial class ReplaceInvalidFilter : AddressFilter.BaseFilter {
+        [GeneratedRegex(@"^['!`\{#\\n\\\\]+(.*)")]
+        public static partial Regex StartsWithCharacter();
+
+        /// <inheritdoc />
+        public override string Name => "TrimIllegalStartChars";
+
+        /// <inheritdoc />
+        public override Result ValidateEmailAddress(ref EmailAddress address) {
+            if (
+                ReplaceInvalidFilter.StartsWithCharacter()
+                    .Match(address.Full) is not { Length: > 0 } match
+            ) return Result.CONTINUE;
+
+            address.Full = match.Groups[1].Value;
+
+            // If the email is now empty, it was only consisting of illegal characters
+            return address.Length is 0 ? Result.DENY : Result.REVALIDATE;
+
+        }
+        
+        
+    }
+}

--- a/src/Objects/Filters/ReplaceInvalidFilter.cs
+++ b/src/Objects/Filters/ReplaceInvalidFilter.cs
@@ -12,13 +12,14 @@ namespace HaveIBeenPwned.AddressExtractor.Objects.Filters {
 
         /// <inheritdoc />
         public override Result ValidateEmailAddress(ref EmailAddress address) {
-            if (
-                ReplaceInvalidFilter.StartsWithCharacter()
-                    .Match(address.Full) is not { Length: > 0 } match
-            ) return Result.CONTINUE;
-
+            Match match = ReplaceInvalidFilter.StartsWithCharacter()
+                .Match(address.Full);
+            
+            if ( match is not { Length: > 0 } )
+                return Result.CONTINUE;
+            
             address.Full = match.Groups[1].Value;
-
+            
             // If the email is now empty, it was only consisting of illegal characters
             return address.Length is 0 ? Result.DENY : Result.REVALIDATE;
 


### PR DESCRIPTION
I removed the block of `.Replace` calls from the `AddressExtractor` class.

Not that this is a corporate environment with a bunch of people editing over eachother, but I wrote the filter system so that there wasn't a spaghetti mess of things overlapping (Including people trying to make overlapping edits). Each filter either accepts or denies an email as valid.

----

I replaced the block of Replaces with a new Filter, so if an address starts with an illegal character (``'!`{#\n\``) it'll trim them from the start. (Rather than a full replace).

Then if there was a replace it'll return `REVALIDATE` which will refilter it against other filters to make sure it's still valid.

----

With filters if one filter removes an illegal character, eg `-`, and another filter checks for valid domains, then you might have something where you pass in the email `@my-test.dom-ain`. The first filter might remove our "illegal" `-` character which results with `@mytest.domain`, and then the second filter will deny `.domain` for being an invalid TLD.

----

For the remaining test you last added `EmailAddressesInExtracted` with the email `foo|test@example.com|bar`, the Filter system needs to be modified because you can only currently return one modified Email address. A filter could see `|` as an illegal character, run a `.Split('|')` for `["foo", "test@example.com", "bar"]` and then run each through the filter system again, where `foo` and `bar` would be skipped.