### PR TITLE
Domains should not be able to end with a period

### DIFF
--- a/src/AddressExtractor.cs
+++ b/src/AddressExtractor.cs
@@ -12,7 +12,7 @@ namespace HaveIBeenPwned.AddressExtractor
         /// Email Regex pattern with simple checks and no backtrack
         /// </summary>
         [GeneratedRegex(
-            """[\\"']*[a-z0-9\.\-\*!#$%&+=?^_`{|}~\\]+@([a-z0-9\-]+[a-z0-9\-]*\.)+[a-z0-9]{2,}\b[\\"']*""",
+            """[\\"']*[a-z0-9\.\-\*!#$%&+=?^_`{|}~\\]+@([a-z0-9\-]+[a-z0-9\-]*\.)+[a-z0-9]{2,}\.?[\\"']*""",
             RegexOptions.ExplicitCapture // Require naming captures; implies '(?:)' on groups. We don't make use of the groups
             | RegexOptions.IgnoreCase // Match upper and lower casing
             | RegexOptions.Compiled // Compile the nodes

--- a/src/Objects/Filters/DomainFilter.cs
+++ b/src/Objects/Filters/DomainFilter.cs
@@ -10,6 +10,10 @@ namespace HaveIBeenPwned.AddressExtractor.Objects.Filters {
         {
             var domain = address.Domain;
 
+            // Handle domain ending in period
+            if (domain[domain.Length - 1].Equals('.'))
+                return Result.DENY;
+
             // Handle cases such as: foo@bar.1com, foo@bar.12com
             if (char.IsNumber(domain[domain.LastIndexOf('.')+1]))
                 return Result.DENY;


### PR DESCRIPTION
Resolves Issue #65.

There was a comment made in issue 65 around stripping the trailing period and keep the address - this was the behaviour of the extractor already.

These changes trigger a successful test but valid emails with a trailing period will no longer be considered valid nor will they be included in the output.

Hopefully this doesn't break anything, all the tests pass (with 4 skipped tests).