### PR TITLE
Fast at scan

### DIFF
--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
@@ -26,6 +27,12 @@ public class AddressExtractorMonitor : IAsyncDisposable
     // ReadLine count
     protected long Lines => _lineCounter;
     private long _lineCounter;
+
+    private long _quickScanCheckedFiles;
+    private long _quickScanSkippedFiles;
+    private long _quickScanBytesRead;
+    private long _quickScanSavedBytes;
+    private long _quickScanTicks;
 
     protected readonly Stopwatch Stopwatch = Stopwatch.StartNew();
     private readonly Timer _timer;
@@ -118,6 +125,32 @@ public class AddressExtractorMonitor : IAsyncDisposable
         using var stack = _stack.CreateStack("Read file");
         Output.Write($"File number {fileCount:n0}");
 
+        if (file.Length >= Config.MinimumFileSizeForAtSymbolQuickScan)
+        {
+            var quickScanStopwatch = Stopwatch.StartNew();
+            var quickScan = await QuickScanForAtSymbolAsync(file, cancellation).ConfigureAwait(false);
+            quickScanStopwatch.Stop();
+
+            stack.Step("Quick '@' scan");
+
+            Interlocked.Increment(ref _quickScanCheckedFiles);
+            Interlocked.Add(ref _quickScanBytesRead, quickScan.BytesRead);
+            Interlocked.Add(ref _quickScanTicks, quickScanStopwatch.Elapsed.Ticks);
+
+            if (!quickScan.ContainsAtSymbol)
+            {
+                Interlocked.Increment(ref _quickScanSkippedFiles);
+                Interlocked.Add(ref _quickScanSavedBytes, file.Length);
+
+                if (Config.Debug)
+                {
+                    Output.Write($"Skipping \"{file.FullName}\" after quick '@' scan [{quickScanStopwatch.Format()}]");
+                }
+
+                return;
+            }
+        }
+
         var lines = 0L;
         var count = new Count();
 
@@ -153,6 +186,22 @@ public class AddressExtractorMonitor : IAsyncDisposable
     public virtual void Log()
     {
         Output.Write($"Extraction time: {Stopwatch.Format()}");
+        Output.Write($"Files parsed: {Files.Count:n0}");
+
+        var checkedFiles = Interlocked.Read(ref _quickScanCheckedFiles);
+        var skippedFiles = Interlocked.Read(ref _quickScanSkippedFiles);
+        var bytesRead = Interlocked.Read(ref _quickScanBytesRead);
+        var savedBytes = Interlocked.Read(ref _quickScanSavedBytes);
+        var quickScanTime = TimeSpan.FromTicks(Interlocked.Read(ref _quickScanTicks));
+        var scanRate = quickScanTime > TimeSpan.Zero
+            ? (long)(bytesRead / quickScanTime.TotalSeconds)
+            : 0L;
+
+        Output.Write($"Quick '@' scan threshold: {ByteExtensions.Format(Config.MinimumFileSizeForAtSymbolQuickScan)}");
+        Output.Write($"Quick '@' scans: {checkedFiles:n0} files in {quickScanTime.Format()}");
+        Output.Write($"Quick '@' scan bytes read: {ByteExtensions.Format(bytesRead)} ({ByteExtensions.Format(scanRate)}/s)");
+        Output.Write($"Quick '@' scan skips: {skippedFiles:n0} files, avoided parsing {ByteExtensions.Format(savedBytes)}");
+
         Output.Write($"Addresses extracted: {Addresses.Count:n0}");
         var rate = (long)(Lines / (Stopwatch.ElapsedMilliseconds / 1000.0));
         Output.Write($"Read lines total: {Lines:n0}");
@@ -201,5 +250,35 @@ public class AddressExtractorMonitor : IAsyncDisposable
 
         await _timer.DisposeAsync().ConfigureAwait(false);
         Stopwatch.Stop();
+    }
+
+    internal static async ValueTask<(bool ContainsAtSymbol, long BytesRead)> QuickScanForAtSymbolAsync(FileInfo file, CancellationToken cancellation = default)
+    {
+        const int bufferSize = 1024 * 64;
+
+        var bytesRead = 0L;
+        var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+        try
+        {
+            await using var stream = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, FileOptions.SequentialScan | FileOptions.Asynchronous);
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(0, bufferSize), cancellation).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    return (false, bytesRead);
+                }
+
+                bytesRead += read;
+                if (buffer.AsSpan(0, read).Contains((byte)'@'))
+                {
+                    return (true, bytesRead);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 }

--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -123,7 +123,6 @@ public class AddressExtractorMonitor : IAsyncDisposable
     public async ValueTask RunAsync(long fileCount, FileInfo file, CancellationToken cancellation = default)
     {
         using var stack = _stack.CreateStack("Read file");
-        Output.Write($"File number {fileCount:n0}");
 
         if (file.Length >= Config.MinimumFileSizeForAtSymbolQuickScan)
         {
@@ -142,10 +141,7 @@ public class AddressExtractorMonitor : IAsyncDisposable
                 Interlocked.Increment(ref _quickScanSkippedFiles);
                 Interlocked.Add(ref _quickScanSavedBytes, file.Length);
 
-                if (Config.Debug)
-                {
-                    Output.Write($"Skipping \"{file.FullName}\" after quick '@' scan [{quickScanStopwatch.Format()}]");
-                }
+                Output.FileResult(fileCount, file.FullName, file.Length, "skipped due to no @ symbol");
 
                 return;
             }
@@ -161,7 +157,8 @@ public class AddressExtractorMonitor : IAsyncDisposable
         // Await any 'continue' prompts
         await _runtime.AwaitContinuationAsync(cancellation).ConfigureAwait(false);
 
-        Output.Write($"Reading \"{file.FullName}\" [{ByteExtensions.Format(file.Length)}]");
+        Output.FileResult(fileCount, file.FullName, file.Length);
+
         await foreach (var line in reader.ReadLineAsync(cancellation).ConfigureAwait(false))
         {
             stack.Step("Read line");
@@ -177,7 +174,7 @@ public class AddressExtractorMonitor : IAsyncDisposable
 
                 if (!Config.Quiet && lines % 250000 is 0)
                 {
-                    Output.Write($"Read {lines:n0} lines from \"{file.Name}\"");
+                    Output.WriteTime($"Read {lines:n0} lines from \"{file.Name}\"");
                 }
             }
         }
@@ -281,4 +278,5 @@ public class AddressExtractorMonitor : IAsyncDisposable
             ArrayPool<byte>.Shared.Return(buffer);
         }
     }
+
 }

--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -92,6 +92,7 @@ internal sealed class FileCollection : IEnumerable<FileInfo>
         var report = Config.ReportFilePath;
         Output.Write($"Output will {(string.IsNullOrWhiteSpace(output) ? "not be saved" : $"be saved to \"{output}\"")}.");
         Output.Write($"Report will {(string.IsNullOrWhiteSpace(report) ? "not be saved" : $"be saved to \"{report}\"")}.");
+        Output.Write($"Quick '@' scan will be used for files {ByteExtensions.Format(Config.MinimumFileSizeForAtSymbolQuickScan)} and larger.");
     }
 
     /// <inheritdoc />

--- a/src/Objects/Config.cs
+++ b/src/Objects/Config.cs
@@ -50,6 +50,9 @@ public sealed class Config
     [CommandLineOption("processAllExtensions", Description = "Process all files regardless of their extension type")]
     public bool ProcessAllExtensions { get; private set; } = Defaults.PROCESS_ALL_EXTENSIONS;
 
+    /// <summary>The minimum file size required before the quick <c>@</c> scan is used</summary>
+    public long MinimumFileSizeForAtSymbolQuickScan { get; } = Defaults.MINIMUM_FILE_SIZE_FOR_AT_SYMBOL_QUICK_SCAN;
+
     [CommandLineOption("?", "h", "help", Description = "Help for the command line arguments", Exclusive = true)]
     public void ShowUsage()
     {
@@ -108,6 +111,7 @@ public sealed class Config
         public const bool DEBUG = false;
         public const bool QUIET = false;
         public const bool PROCESS_ALL_EXTENSIONS = false;
+        public const long MINIMUM_FILE_SIZE_FOR_AT_SYMBOL_QUICK_SCAN = 10 * 1000 * 1000;
     }
 
     internal delegate void Writer(string value);

--- a/src/Objects/Output.cs
+++ b/src/Objects/Output.cs
@@ -7,6 +7,12 @@ public static class Output
     public static void Write(string line)
         => Write(Console.Out, line);
 
+    public static void WriteTime(string line)
+        => Console.Out.WriteLine($"[{Time()}] {line}");
+
+    public static void FileResult(long fileNumber, string path, long bytes, string? result = null)
+        => WriteTime($"File number {fileNumber:n0} {path} [{ByteExtensions.Format(bytes)}]{(string.IsNullOrWhiteSpace(result) ? string.Empty : $" - {result}")}");
+
     public static void Exception(Exception ex, bool trace = true)
         => Write(Console.Error, trace ? ex : ex.Message);
 
@@ -29,6 +35,9 @@ public static class Output
 
         to.WriteLine($"[{DateTime()}] {e}");
     }
+
+    private static string Time()
+        => System.DateTime.Now.ToString("HH:mm:ss", CultureInfo.CurrentCulture);
 
     private static string DateTime()
         => System.DateTime.Now.ToString(CultureInfo.CurrentCulture);

--- a/test/CommandLineProcessorTests.cs
+++ b/test/CommandLineProcessorTests.cs
@@ -191,6 +191,16 @@ public class CommandLineProcessorTests
         }
     }
 
+    [TestMethod]
+    public void QuickAtCheckThresholdDefaultsToTenMegabytes()
+    {
+        var args = new[] { "input" };
+
+        var config = CommandLineProcessor.Parse(args, out _);
+
+        Assert.AreEqual(10 * 1000 * 1000, config.MinimumFileSizeForAtSymbolQuickScan, "Quick '@' scan threshold should default to 10 MB");
+    }
+
     #endregion
     #region File Inputs
 

--- a/test/QuickAtSymbolScanTests.cs
+++ b/test/QuickAtSymbolScanTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HaveIBeenPwned.AddressExtractor.Tests;
+
+[TestClass]
+public class QuickAtSymbolScanTests
+{
+    [TestMethod]
+    public async Task QuickScanFindsAtSymbolAsync()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(path, "before\ntest@example.com\nafter").ConfigureAwait(false);
+
+            var file = new FileInfo(path);
+            var (containsAtSymbol, bytesRead) = await AddressExtractorMonitor.QuickScanForAtSymbolAsync(file).ConfigureAwait(false);
+
+            Assert.IsTrue(containsAtSymbol, "Quick scan should find '@' when the file contains one");
+            Assert.IsTrue(bytesRead > 0, "Quick scan should read at least part of the file");
+            Assert.IsTrue(bytesRead <= file.Length, "Quick scan should not report reading more than the file length");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    public async Task QuickScanStopsAtEndWhenNoAtSymbolExistsAsync()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(path, "before\nno email addresses here\nafter").ConfigureAwait(false);
+
+            var file = new FileInfo(path);
+            var (containsAtSymbol, bytesRead) = await AddressExtractorMonitor.QuickScanForAtSymbolAsync(file).ConfigureAwait(false);
+
+            Assert.IsFalse(containsAtSymbol, "Quick scan should return false when the file contains no '@'");
+            Assert.AreEqual(file.Length, bytesRead, "Quick scan should read the full file when no '@' is found");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses an issue that only appears with very large incidents, such as multi-TB breaches with thousands of files. Often, there are a lot of files that don't have email addresses, but we were doing expensive row-by-row checks looking for them. Once a file is any more than 10MB, we now check for an @ symbol and if one isn't found, don't even bother doing row-level checks. It's simple, dumb logic, and it works great 😊