### PR TITLE
Ensured a unique report file per breach process

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Syntax: `AddressExtractor.exe <input [[... input]]> [-o output] [-r report]`
 | `-v`, `--version`       | Prints the application version number                                      |
 | input                   | One or more input filenames or directories                                 |
 | `-o`, `--output` output | Path and filename of the output file. Defaults to 'addresses_output.txt'   |
-| `-r`, `--report` report | Path and filename of the report file. Defaults to 'report.txt'             |
+| `-r`, `--report` report | Reports are saved as `<output>.report.txt` |
 | `--recursive`           | Enable recursive mode for directories, which will search child directories |
 | `--processAllExtensions`| Process all files regardless of their extension type                       |
 | `-y`, `--yes`           | Automatically confirm prompts to CONTINUE without asking                   |

--- a/src/Objects/Config.cs
+++ b/src/Objects/Config.cs
@@ -22,8 +22,12 @@ public sealed class Config
     public string OutputFilePath { get; private set; } = Defaults.OUTPUT_FILE_PATH;
 
     /// <summary>The path to write the summary report to</summary>
-    [CommandLineOption("r", "report", Description = "File path to write report file", Expects = "path")]
-    public string ReportFilePath { get; private set; } = Defaults.REPORT_FILE_PATH;
+    [CommandLineOption("r", "report", Description = "Legacy option retained for compatibility; report files are saved to the output path with a '.report.txt' suffix", Expects = "path")]
+    public string ReportFilePath
+    {
+        get => string.IsNullOrWhiteSpace(OutputFilePath) ? string.Empty : $"{OutputFilePath}{Defaults.REPORT_FILE_SUFFIX}";
+        private set { }
+    }
 
     /// <summary>If the prompt to Continue should be skipped</summary>
     [CommandLineOption("y", "yes", Description = "Skips any normal continue prompts")]
@@ -100,7 +104,8 @@ public sealed class Config
     public static class Defaults
     {
         public const string OUTPUT_FILE_PATH = "addresses_output.txt";
-        public const string REPORT_FILE_PATH = "report.txt";
+        public const string REPORT_FILE_SUFFIX = ".report.txt";
+        public const string REPORT_FILE_PATH = OUTPUT_FILE_PATH + REPORT_FILE_SUFFIX;
 
         public const bool OPERATE_RECURSIVELY = false;
         public const bool SKIP_PROMPTS = false;

--- a/test/CommandLineProcessorTests.cs
+++ b/test/CommandLineProcessorTests.cs
@@ -252,7 +252,7 @@ public class CommandLineProcessorTests
         Assert.AreEqual(inputs.Count, 1);
         Assert.AreEqual(inputs[0], args[0]);
         Assert.AreEqual(config.OutputFilePath, args[2]);
-        Assert.AreEqual(config.ReportFilePath, Config.Defaults.REPORT_FILE_PATH);
+        Assert.AreEqual(config.ReportFilePath, $"{args[2]}{Config.Defaults.REPORT_FILE_SUFFIX}");
     }
 
     [TestMethod]
@@ -268,7 +268,7 @@ public class CommandLineProcessorTests
         Assert.AreEqual(inputs.Count, 1);
         Assert.AreEqual(inputs[0], args[0]);
         Assert.AreEqual(config.OutputFilePath, Config.Defaults.OUTPUT_FILE_PATH);
-        Assert.AreEqual(config.ReportFilePath, args[2]);
+        Assert.AreEqual(config.ReportFilePath, Config.Defaults.REPORT_FILE_PATH);
     }
 
     [TestMethod]
@@ -284,7 +284,7 @@ public class CommandLineProcessorTests
         Assert.AreEqual(inputs.Count, 1);
         Assert.AreEqual(inputs[0], args[0]);
         Assert.AreEqual(config.OutputFilePath, args[2]);
-        Assert.AreEqual(config.ReportFilePath, args[4]);
+        Assert.AreEqual(config.ReportFilePath, $"{args[2]}{Config.Defaults.REPORT_FILE_SUFFIX}");
     }
 
     [TestMethod]
@@ -300,7 +300,7 @@ public class CommandLineProcessorTests
         Assert.AreEqual(inputs.Count, 1);
         Assert.AreEqual(inputs[0], args[0]);
         Assert.AreEqual(config.OutputFilePath, args[4]);
-        Assert.AreEqual(config.ReportFilePath, args[2]);
+        Assert.AreEqual(config.ReportFilePath, $"{args[4]}{Config.Defaults.REPORT_FILE_SUFFIX}");
     }
 
     [TestMethod]
@@ -317,7 +317,7 @@ public class CommandLineProcessorTests
         Assert.AreEqual(inputs[0], args[0]);
         Assert.AreEqual(inputs[1], args[1]);
         Assert.AreEqual(config.OutputFilePath, args[3]);
-        Assert.AreEqual(config.ReportFilePath, Config.Defaults.REPORT_FILE_PATH);
+        Assert.AreEqual(config.ReportFilePath, $"{args[3]}{Config.Defaults.REPORT_FILE_SUFFIX}");
     }
 
     [TestMethod]
@@ -334,6 +334,19 @@ public class CommandLineProcessorTests
         Assert.AreEqual(inputs[0], args[0]);
         Assert.AreEqual(inputs[1], args[3]);
         Assert.AreEqual(config.OutputFilePath, args[2]);
-        Assert.AreEqual(config.ReportFilePath, Config.Defaults.REPORT_FILE_PATH);
+        Assert.AreEqual(config.ReportFilePath, $"{args[2]}{Config.Defaults.REPORT_FILE_SUFFIX}");
+    }
+
+    [TestMethod]
+    public void ReportPathKeepsOutputExtension()
+    {
+        // Arrange
+        var args = new[] { "input1", "-o", "test.txt" };
+
+        // Act
+        var config = CommandLineProcessor.Parse(args, out _);
+
+        // Assert
+        Assert.AreEqual("test.txt.report.txt", config.ReportFilePath);
     }
 }


### PR DESCRIPTION
Previously, running the tool back-to-back resulted in the report file always being overwritten. This PR ensures there's a unique report file per breach process.