### PR TITLE
Implement PDF reader using PdfPig

### DIFF
--- a/src/AddressExtractor.csproj
+++ b/src/AddressExtractor.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />
+    <PackageReference Include="PdfPig" Version="0.1.14" />
   </ItemGroup>
 
 </Project>

--- a/src/Objects/Readers/PdfReader.cs
+++ b/src/Objects/Readers/PdfReader.cs
@@ -1,15 +1,26 @@
+using System.Runtime.CompilerServices;
 using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.DocumentLayoutAnalysis.TextExtractor;
 
 namespace HaveIBeenPwned.AddressExtractor.Objects.Readers;
 
 [ExtensionTypes(".pdf")]
-public sealed class PdfReader : ILineReader
+internal sealed class PdfReader(string path) : ILineReader
 {
     /// <inheritdoc />
-    public IAsyncEnumerable<string?> ReadLineAsync(CancellationToken cancellation = default)
-        => throw new NotImplementedException();
+    public async IAsyncEnumerable<string?> ReadLineAsync([EnumeratorCancellation] CancellationToken cancellation = default)
+    {
+        using var document = PdfDocument.Open(path);
+        foreach (var page in document.GetPages())
+        {
+            cancellation.ThrowIfCancellationRequested();
+            var text = ContentOrderTextExtractor.GetText(page);
+            await Task.Yield();
+            yield return text;
+        }
+    }
 
     /// <inheritdoc />
-    public ValueTask DisposeAsync()
-        => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -30,6 +30,16 @@ public class AddressExtractorTests
     }
 
     [TestMethod]
+    public async Task EmailAddressIsExtractedFromPdfFileAsync()
+    {
+        var result = await ExtractAddressesFromFileAsync(@"../../../../TestData/SingleFile/PdfFile.pdf").ConfigureAwait(false);
+
+        // Assert
+        Assert.AreEqual(1, result.Count, "One email address should be extracted from the PDF");
+        Assert.AreEqual("emailemail@email.com", result.First(), "The extracted email should match the PDF contents");
+    }
+
+    [TestMethod]
     public async Task AddressAfterBlankLineIsFoundAsync()
     {
         var result = await ExtractAddressesFromFileAsync(@"../../../../TestData/SingleFile/FileWithBlankLine.txt").ConfigureAwait(false);


### PR DESCRIPTION
## Summary

Adds support for extracting email addresses from `.pdf` files.

- Implements the previously stubbed `PdfReader` using [PdfPig](https://github.com/UglyToad/PdfPig) 0.1.14 to extract text from `.pdf` files page-by-page
- Each page's text is yielded as a single line via `ContentOrderTextExtractor`, with `Task.Yield()` to keep the async pipeline cooperative and `CancellationToken` honored between pages
- Adds a unit test covering email extraction from `TestData/SingleFile/PdfFile.pdf`

Refs #46.

## Testing

```
$ dotnet test
Restore complete (0.2s)
  AddressExtractor net9.0 succeeded (0.1s) → src/bin/Debug/net9.0/AddressExtractor.dll
  AddressExtractorTest net9.0 succeeded (0.1s) → test/bin/Debug/net9.0/AddressExtractorTest.dll
  AddressExtractorTest test net9.0 succeeded (0.6s)

Test summary: total: 107, failed: 0, succeeded: 105, skipped: 2, duration: 0.6s
Build succeeded in 1.1s
```

Ran `--debug` against a larger PDF (38.6 Kb, 17 pages):
```
$ dotnet run --project src -- pdf-testfile.pdf -y --debug
[4/25/2026 11:29:11 PM] Found 1 files:
[4/25/2026 11:29:11 PM]   .pdf   1 files: 38.6 Kb
...
[4/25/2026 11:29:12 PM] Addresses extracted: 990
[4/25/2026 11:29:12 PM] Read lines total: 990
[4/25/2026 11:29:12 PM] Read lines rate: 4,541/s

 - Read file x1 | Took 213ms (at ~213ms per)
   - Read line x17 | Took 188ms (at ~11ms per)
```