### PR TITLE
Report now counts distinct emails per file

### DIFF
--- a/src/AddressExtractorMonitor.cs
+++ b/src/AddressExtractorMonitor.cs
@@ -80,10 +80,9 @@ public class AddressExtractorMonitor : IAsyncDisposable
                     // Extract addresses from the line
                     foreach (var email in AddressExtractor.ExtractAddresses(line.Value))
                     {
-                        if (Addresses.TryAdd(email, 0))
-                        {
-                            line.Counter.Increment();
-                        }
+                        line.Counter.TryAdd(email);
+
+                        Addresses.TryAdd(email, 0);
 
                         Interlocked.Increment(ref _lineCounter);
 

--- a/src/Count.cs
+++ b/src/Count.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace HaveIBeenPwned.AddressExtractor;
 
 /// <summary>
@@ -9,9 +11,21 @@ public sealed class Count
 {
     public long Value => _value;
     private long _value;
+    private readonly ConcurrentDictionary<string, byte> _addresses = new(StringComparer.OrdinalIgnoreCase);
 
     public void Increment()
         => Interlocked.Increment(ref _value);
+
+    public bool TryAdd(string address)
+    {
+        if (!_addresses.TryAdd(address, 0))
+        {
+            return false;
+        }
+
+        Increment();
+        return true;
+    }
 
     /// <inheritdoc />
     public override string ToString()

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -49,6 +49,54 @@ public class AddressExtractorTests
     }
 
     [TestMethod]
+    public async Task ReportCountsUniqueAddressesWithinEachFileAsync()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"EmailAddressExtractorTests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var inputDirectory = Path.Combine(tempRoot, "input");
+            Directory.CreateDirectory(inputDirectory);
+
+            var file1 = Path.Combine(inputDirectory, "File1.txt");
+            var file2 = Path.Combine(inputDirectory, "File2.txt");
+
+            await File.WriteAllLinesAsync(file1,
+            [
+                "shared@example.com",
+                "shared@example.com",
+                "first@example.com"
+            ]).ConfigureAwait(false);
+
+            await File.WriteAllLinesAsync(file2,
+            [
+                "shared@example.com",
+                "second@example.com",
+                "second@example.com"
+            ]).ConfigureAwait(false);
+
+            var outputPath = Path.Combine(tempRoot, "addresses.txt");
+            var exitCode = await Program.Main([inputDirectory, "-y", "-o", outputPath]).ConfigureAwait(false);
+
+            Assert.AreEqual(0, exitCode, "Extraction should succeed");
+
+            var reportPath = $"{outputPath}{Config.Defaults.REPORT_FILE_SUFFIX}";
+            var report = await File.ReadAllTextAsync(reportPath).ConfigureAwait(false);
+
+            StringAssert.Contains(report, $"{file1}: 2", "The first file should count its own unique addresses, including addresses seen in other files");
+            StringAssert.Contains(report, $"{file2}: 2", "The second file should count its own unique addresses, including addresses seen in other files");
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
     public void EmailAddressesAreNotCaseSensitive()
     {
         const string ADDRESSES = "test@example.com TEST@EXAMPLE.COM";


### PR DESCRIPTION
This PR ensures that the report lists the correct number of addresses per file. Previously, it only listed *new* distinct addresses not already seen in other files which made it hard to accurately assess where the spread of addresses was.