### PR TITLE
Add SQLite reader for email extraction

### DIFF
--- a/src/AddressExtractor.csproj
+++ b/src/AddressExtractor.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />
     <PackageReference Include="PdfPig" Version="0.1.14" />
   </ItemGroup>

--- a/src/Objects/Readers/SqliteReader.cs
+++ b/src/Objects/Readers/SqliteReader.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+using HaveIBeenPwned.AddressExtractor.Objects.Attributes;
+
+using Microsoft.Data.Sqlite;
+
+namespace HaveIBeenPwned.AddressExtractor.Objects.Readers;
+
+[ExtensionTypes(".sqlite")]
+internal sealed class SqliteReader : ILineReader
+{
+    private readonly SqliteConnection _connection;
+
+    public SqliteReader(string path)
+    {
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = path,
+            Mode = SqliteOpenMode.ReadOnly,
+            Pooling = false
+        }.ToString();
+
+        _connection = new SqliteConnection(connectionString);
+    }
+
+    public async IAsyncEnumerable<string?> ReadLineAsync([EnumeratorCancellation] CancellationToken cancellation = default)
+    {
+        if (_connection.State != System.Data.ConnectionState.Open)
+        {
+            await _connection.OpenAsync(cancellation).ConfigureAwait(false);
+        }
+
+        var tableNames = await ReadTableNamesAsync(cancellation).ConfigureAwait(false);
+        foreach (var tableName in tableNames)
+        {
+            await foreach (var row in ReadTableRowsAsync(tableName, cancellation).ConfigureAwait(false))
+            {
+                yield return row;
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _connection.CloseAsync().ConfigureAwait(false);
+        await _connection.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private async Task<List<string>> ReadTableNamesAsync(CancellationToken cancellation)
+    {
+        var tableNames = new List<string>();
+
+        await using var command = _connection.CreateCommand();
+        command.CommandText = """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+            ORDER BY name;
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellation).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellation).ConfigureAwait(false))
+        {
+            if (!reader.IsDBNull(0) && reader.GetString(0) is { Length: > 0 } tableName)
+            {
+                tableNames.Add(tableName);
+            }
+        }
+
+        return tableNames;
+    }
+
+    private async IAsyncEnumerable<string?> ReadTableRowsAsync(string tableName, [EnumeratorCancellation] CancellationToken cancellation)
+    {
+        await using var command = _connection.CreateCommand();
+        command.CommandText = $"SELECT * FROM {QuoteIdentifier(tableName)}";
+
+        await using var reader = await command.ExecuteReaderAsync(cancellation).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellation).ConfigureAwait(false))
+        {
+            cancellation.ThrowIfCancellationRequested();
+
+            var values = new List<string>();
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                if (TryFormatValue(reader.GetValue(i), out var value))
+                {
+                    values.Add(value);
+                }
+            }
+
+            if (values.Count > 0)
+            {
+                yield return $"{tableName}\t{string.Join('\t', values)}";
+            }
+        }
+    }
+
+    private static string QuoteIdentifier(string identifier)
+        => $"\"{identifier.Replace("\"", "\"\"")}\"";
+
+    private static bool TryFormatValue(object value, out string text)
+    {
+        switch (value)
+        {
+            case null:
+            case DBNull:
+                text = string.Empty;
+                return false;
+            case string s when string.IsNullOrWhiteSpace(s):
+                text = string.Empty;
+                return false;
+            case string s:
+                text = s;
+                return true;
+            case byte[] bytes when bytes.Length == 0:
+                text = string.Empty;
+                return false;
+            case byte[] bytes:
+                text = Encoding.UTF8.GetString(bytes);
+                return !string.IsNullOrWhiteSpace(text);
+            default:
+                text = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+                return !string.IsNullOrWhiteSpace(text);
+        }
+    }
+}

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -1,5 +1,6 @@
 using HaveIBeenPwned.AddressExtractor.Objects;
 
+using Microsoft.Data.Sqlite;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HaveIBeenPwned.AddressExtractor.Tests;
@@ -61,6 +62,58 @@ public class AddressExtractorTests
 
             Assert.AreEqual(1, result.Count, "One email address should be extracted from the YAML file");
             Assert.AreEqual("yamltest@example.com", result.First(), "The extracted email should match the YAML contents");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task EmailAddressIsExtractedFromSqliteFileAsync()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"EmailAddressExtractorTests-{Guid.NewGuid():N}.sqlite");
+
+        try
+        {
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = tempFile,
+                Pooling = false
+            }.ToString();
+
+            await using (var connection = new SqliteConnection(connectionString))
+            {
+                await connection.OpenAsync().ConfigureAwait(false);
+
+                await using var command = connection.CreateCommand();
+                command.CommandText = """
+                    CREATE TABLE users (email TEXT, notes TEXT);
+                    INSERT INTO users (email, notes)
+                    VALUES ('sqlite@example.com', 'backup: sqlite-alt@example.com');
+
+                    CREATE TABLE audit (details TEXT);
+                    INSERT INTO audit (details)
+                    VALUES ('seen by sqlite-audit@example.com');
+                    """;
+
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+
+            var result = await ExtractAddressesFromFileAsync(tempFile).ConfigureAwait(false);
+
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    "sqlite@example.com",
+                    "sqlite-alt@example.com",
+                    "sqlite-audit@example.com"
+                },
+                result.ToArray(),
+                "The extractor should parse email addresses from SQLite table data");
         }
         finally
         {


### PR DESCRIPTION
Introduce a new `.sqlite` line reader that opens databases in read-only mode, iterates non-system tables, and emits row values for address parsing. Add `Microsoft.Data.Sqlite` to the project and extend tests with an end-to-end SQLite fixture to verify addresses are extracted across multiple tables and text fields.