### PR TITLE
Skip unreadable input paths gracefully

### DIFF
--- a/src/FileCollection.cs
+++ b/src/FileCollection.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Security;
 
 using HaveIBeenPwned.AddressExtractor.Objects;
 
@@ -29,12 +30,33 @@ internal sealed class FileCollection : IEnumerable<FileInfo>
     {
         foreach (var file in inputs)
         {
-            var attributes = File.GetAttributes(file);
+            FileAttributes attributes;
+            try
+            {
+                attributes = File.GetAttributes(file);
+            }
+            catch (Exception ex) when (IsSkippableFileSystemException(ex))
+            {
+                LogSkippedPath(file, ex);
+                continue;
+            }
+
             if (attributes.HasFlag(FileAttributes.Directory))
             {
                 if (!recursed || Config.OperateRecursively)
                 {
-                    foreach (var enumerated in GatherFiles(Directory.EnumerateFileSystemEntries(file), recursed: true))
+                    IEnumerable<string> entries;
+                    try
+                    {
+                        entries = Directory.EnumerateFileSystemEntries(file);
+                    }
+                    catch (Exception ex) when (IsSkippableFileSystemException(ex))
+                    {
+                        LogSkippedPath(file, ex);
+                        continue;
+                    }
+
+                    foreach (var enumerated in GatherFiles(entries, recursed: true))
                     {
                         yield return enumerated;
                     }
@@ -67,11 +89,21 @@ internal sealed class FileCollection : IEnumerable<FileInfo>
         var infos = new ConcurrentDictionary<string, ExtensionInfo>(StringComparer.OrdinalIgnoreCase);
         var count = Files.Count; // Cache the count before removing
 
-        foreach (var file in this)
+        foreach (var file in Files.Values.ToArray())
         {
             var extension = file.Extension is { Length: > 0 } ext ? ext : "(no extension)";
             var info = infos.GetOrAdd(extension, _ => new ExtensionInfo(Runtime, extension.ToLower()));
-            info.AddFile(file);
+
+            try
+            {
+                info.AddFile(file);
+            }
+            catch (Exception ex) when (IsSkippableFileSystemException(ex))
+            {
+                Files.Remove(file.FullName);
+                LogSkippedPath(file.FullName, ex);
+                continue;
+            }
 
             // Remove ignored files
             if (!Config.ProcessAllExtensions && !info.Parsing.Read)
@@ -102,6 +134,20 @@ internal sealed class FileCollection : IEnumerable<FileInfo>
     /// <inheritdoc />
     IEnumerator IEnumerable.GetEnumerator()
         => GetEnumerator();
+
+    private static bool IsSkippableFileSystemException(Exception ex)
+        => ex is IOException or UnauthorizedAccessException or NotSupportedException or SecurityException or ArgumentException;
+
+    private void LogSkippedPath(string path, Exception ex)
+    {
+        if (Config.Debug)
+        {
+            Output.Exception(new IOException($"Skipping '{path}':", ex));
+            return;
+        }
+
+        Output.Notice($"Skipping '{path}': {ex.Message}");
+    }
 
     private class ExtensionInfo(Runtime runtime, string extension)
     {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Security;
 
 using HaveIBeenPwned.AddressExtractor.Objects;
 using HaveIBeenPwned.AddressExtractor.Objects.Performance;
@@ -57,7 +58,7 @@ public class Program
             await using (var monitor = new AddressExtractorMonitor(runtime, perf))
             {
                 var fileCount = 0L;
-                foreach (var file in files.OrderBy(f => f.Length))
+                foreach (var file in files.OrderBy(GetFileLengthOrMax))
                 {
                     fileCount++;
                     try
@@ -134,4 +135,19 @@ public class Program
 
         return (int)ErrorCode.NoError;
     }
+
+    private static long GetFileLengthOrMax(FileInfo file)
+    {
+        try
+        {
+            return file.Length;
+        }
+        catch (Exception ex) when (IsSkippableFileSystemException(ex))
+        {
+            return long.MaxValue;
+        }
+    }
+
+    private static bool IsSkippableFileSystemException(Exception ex)
+        => ex is IOException or UnauthorizedAccessException or NotSupportedException or SecurityException or ArgumentException;
 }

--- a/test/AddressExtractorTests.cs
+++ b/test/AddressExtractorTests.cs
@@ -173,6 +173,48 @@ public class AddressExtractorTests
     }
 
     [TestMethod]
+    public async Task MissingInputFileIsSkippedAndExtractionContinuesAsync()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"EmailAddressExtractorTests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var validFile = Path.Combine(tempRoot, "ValidInput.txt");
+            var missingFile = Path.Combine(tempRoot, "MissingInput.txt");
+            var outputPath = Path.Combine(tempRoot, "addresses.txt");
+
+            await File.WriteAllLinesAsync(validFile,
+            [
+                "valid@example.com",
+                "other@example.com"
+            ]).ConfigureAwait(false);
+
+            var exitCode = await Program.Main([validFile, missingFile, "-y", "-o", outputPath]).ConfigureAwait(false);
+
+            Assert.AreEqual(0, exitCode, "Extraction should succeed even if one input file cannot be read");
+
+            var extracted = await File.ReadAllLinesAsync(outputPath).ConfigureAwait(false);
+
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    "other@example.com",
+                    "valid@example.com"
+                },
+                extracted,
+                "Valid files should still be processed when an invalid input path is skipped");
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
     public void EmailAddressesAreNotCaseSensitive()
     {
         const string ADDRESSES = "test@example.com TEST@EXAMPLE.COM";


### PR DESCRIPTION
Handle filesystem access errors while collecting and classifying input files so missing, inaccessible, or invalid paths are skipped instead of terminating extraction. File ordering now uses a safe length accessor to avoid failures when metadata cannot be read. Added a regression test to confirm extraction still succeeds and outputs addresses from valid inputs when one input path is missing.